### PR TITLE
Error Propagation

### DIFF
--- a/autodepgraph/graph.py
+++ b/autodepgraph/graph.py
@@ -33,7 +33,9 @@ class Graph(Instrument):
                 # If the node does not exist, create a new node
                 node = CalibrationNode(node_snap['name'])
 
-            pars_to_update = ['parents', 'children', 'check_functions',
+            # children are not set because it is automatically set when
+            # parents are set.
+            pars_to_update = ['parents', 'check_functions',
                               'calibrate_functions']
             if load_node_state:
                 pars_to_update += ['state']

--- a/autodepgraph/graph.py
+++ b/autodepgraph/graph.py
@@ -33,7 +33,7 @@ class Graph(Instrument):
                 # If the node does not exist, create a new node
                 node = CalibrationNode(node_snap['name'])
 
-            pars_to_update = ['dependencies', 'check_functions',
+            pars_to_update = ['parents', 'children', 'check_functions',
                               'calibrate_functions']
             if load_node_state:
                 pars_to_update += ['state']

--- a/autodepgraph/graph.py
+++ b/autodepgraph/graph.py
@@ -33,8 +33,10 @@ class Graph(Instrument):
                 # If the node does not exist, create a new node
                 node = CalibrationNode(node_snap['name'])
 
-            # children are not set because it is automatically set when
-            # parents are set.
+            # children is not in pars_to_update because the children are set
+            # whenever a node is added as a parent to another node. This means
+            # that loading and setting parents for all node automatically also
+            # sets the children for all nodes correctly.
             pars_to_update = ['parents', 'check_functions',
                               'calibrate_functions']
             if load_node_state:

--- a/autodepgraph/node.py
+++ b/autodepgraph/node.py
@@ -31,9 +31,9 @@ class CalibrationNode(Instrument):
         self.add_parameter('parents',
                            docstring='List of names of nodes '
                                      'on which this node depends. '
-                                     'Add nodes to parents using the '
-                                     'add_parent method.',
-                           set_cmd=self._set_parents,
+                                     'To add or remove nodes use the '
+                                     'add_parent and remove_parent '
+                                     'methods.',
                            get_cmd=self._get_parents,
                            vals=vals.Lists(vals.Strings()))
         self._parents = []
@@ -44,7 +44,6 @@ class CalibrationNode(Instrument):
                                      'Children are automatically added '
                                      'whenever this node is added as a '
                                      'parent to another node.',
-                           set_cmd=self._set_children,
                            get_cmd=self._get_children,
                            vals=vals.Lists(vals.Strings()))
         self._children = []
@@ -94,20 +93,8 @@ class CalibrationNode(Instrument):
             self._state = 'needs calibration'
         return self._state
 
-    def _set_parents(self, val):
-        '''
-        Sets the parents parameter by calling the add_parent method for every
-        item. This ensures that this node is also added to the children of
-        the other nodes.
-        '''
-        for i in val:
-            self.add_parent(i)
-
     def _get_parents(self):
         return self._parents
-
-    def _set_children(self, val):
-        logging.warning('Manually setting children not allowed!')
 
     def _get_children(self):
         return self._children

--- a/autodepgraph/node.py
+++ b/autodepgraph/node.py
@@ -34,6 +34,7 @@ class CalibrationNode(Instrument):
                                      'To add or remove nodes use the '
                                      'add_parent and remove_parent '
                                      'methods.',
+                           set_cmd=self._set_parents,
                            get_cmd=self._get_parents,
                            vals=vals.Lists(vals.Strings()))
         self._parents = []
@@ -92,6 +93,18 @@ class CalibrationNode(Instrument):
         if deltaT > self.calibration_timeout():
             self._state = 'needs calibration'
         return self._state
+
+    def _set_parents(self, val):
+        '''
+        Sets the parents to val by first removing all parents with
+        remove_parent and then calling add_parent for every item
+        in val.
+        '''
+        for i in self.parents():
+            self.remove_parent(i)
+
+        for i in val:
+            self.add_parent(i)
 
     def _get_parents(self):
         return self._parents

--- a/autodepgraph/node.py
+++ b/autodepgraph/node.py
@@ -138,7 +138,7 @@ class CalibrationNode(Instrument):
         The argument node can be a string, or a node object, or a
         list/numpy.array of these types.
         '''
-        if type(node) is list or type(node) is np.ndarray:
+        if isinstance(node, list) or isinstance(node, np.ndarray):
             for i in node:
                 self.add_parent(i)
         else:
@@ -163,7 +163,7 @@ class CalibrationNode(Instrument):
         node from the child nodes of the removed parent.
         node can be a string or a node object.
         '''
-        if type(node) is list or type(node) is np.ndarray:
+        if isinstance(node, list) or isinstance(node, np.ndarray):
             for i in node:
                 self.remove_parent(i)
         else:

--- a/autodepgraph/node.py
+++ b/autodepgraph/node.py
@@ -29,13 +29,13 @@ class CalibrationNode(Instrument):
                            vals=vals.Numbers(min_value=0))
 
         self.add_parameter('parents',
-                           docstring='List of names of Calibration nodes '
+                           docstring='List of names of nodes '
                                      + 'on which this node depends',
                            initial_value=[],
                            vals=vals.Lists(vals.Strings()),
                            parameter_class=ManualParameter)
         self.add_parameter('children',
-                           docstring='List of names of Calibration nodes '
+                           docstring='List of names of nodes '
                                      + 'which depend on this node',
                            initial_value=[],
                            vals=vals.Lists(vals.Strings()),

--- a/autodepgraph/node.py
+++ b/autodepgraph/node.py
@@ -73,6 +73,9 @@ class CalibrationNode(Instrument):
         self._calib_cnt = 0
         self._check_cnt = 0
 
+    def __call__(self, verbose=False):
+        return self.execute_node(verbose=verbose)
+
     def _set_state(self, val):
         self.state._latest_set_ts = datetime.now()
         self._state = val
@@ -82,9 +85,6 @@ class CalibrationNode(Instrument):
         if deltaT > self.calibration_timeout():
             self._state = 'needs calibration'
         return self._state
-
-    def __call__(self, verbose=False):
-        return self.execute_node(verbose=verbose)
 
     def close(self):
         '''
@@ -97,8 +97,9 @@ class CalibrationNode(Instrument):
             try:
                 self.find_instrument(node).remove_child(self.name)
             except KeyError:
-                logging.warning('Could not remove reference from node "{}": '
-                                .format(node) + 'node not found')
+                # if the other node is not found, the reference does not need
+                # to be removed anyway
+                pass
 
         super().close()
 

--- a/autodepgraph/node.py
+++ b/autodepgraph/node.py
@@ -137,7 +137,7 @@ class CalibrationNode(Instrument):
             parentNode = self.find_instrument(name)
             if self.name in parentNode.children():
                 parentNode.children().remove(self.name)
-        except:
+        except KeyError:
             logging.warning('Parent node "{}" not found.'.format(name))
 
     def propagate_error(self, state):

--- a/autodepgraph/tests/test_data/test_graph_new_nodes.yaml
+++ b/autodepgraph/tests/test_data/test_graph_new_nodes.yaml
@@ -1,90 +1,226 @@
 meta: {}
 nodes:
   A:
-    __class__: autodepgraph.graph.CalibrationNode
+    __class__: autodepgraph.node.CalibrationNode
     functions: {}
     name: A
     parameters:
-      IDN: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.graph.CalibrationNode,
+      IDN: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
         instrument_name: A, label: IDN, name: IDN, ts: null, unit: '', vals: <Anything>,
         value: null}
-      calibrate_functions: {__class__: qcodes.instrument.parameter.ManualParameter,
-        instrument: autodepgraph.graph.CalibrationNode, instrument_name: A, label: calibrate_functions,
-        name: calibrate_functions, ts: null, unit: '', vals: '<Lists : <Strings>>',
-        value: null}
-      check_functions: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.graph.CalibrationNode,
-        instrument_name: A, label: check_functions, name: check_functions, ts: null,
-        unit: '', vals: '<Lists : <Strings>>', value: null}
-      dependencies: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.graph.CalibrationNode,
-        instrument_name: A, label: dependencies, name: dependencies, ts: null, unit: '',
-        vals: '<Lists : <Strings>>', value: null}
-      state: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.graph.CalibrationNode,
-        instrument_name: A, label: state, name: state, ts: '2017-04-29 16:41:13',
-        unit: '', vals: '<Enum: {''good'', ''unknown'', ''active'', ''needs calibration'',
+      calibrate_functions:
+        __class__: qcodes.instrument.parameter.ManualParameter
+        instrument: autodepgraph.node.CalibrationNode
+        instrument_name: A
+        label: calibrate_functions
+        name: calibrate_functions
+        ts: '2017-05-23 10:02:16'
+        unit: ''
+        vals: '<Lists : <Strings>>'
+        value: []
+      calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
+        instrument: autodepgraph.node.CalibrationNode, instrument_name: A, label: calibration_timeout,
+        name: calibration_timeout, ts: '2017-05-23 10:02:16', unit: s, vals: <Numbers
+          v>=0>, value: .inf}
+      check_functions:
+        __class__: qcodes.instrument.parameter.ManualParameter
+        instrument: autodepgraph.node.CalibrationNode
+        instrument_name: A
+        label: check_functions
+        name: check_functions
+        ts: '2017-05-23 10:02:16'
+        unit: ''
+        vals: '<Lists : <Strings>>'
+        value: []
+      children:
+        __class__: qcodes.instrument.parameter.ManualParameter
+        instrument: autodepgraph.node.CalibrationNode
+        instrument_name: A
+        label: children
+        name: children
+        ts: '2017-05-23 10:02:16'
+        unit: ''
+        vals: '<Lists : <Strings>>'
+        value: []
+      parents:
+        __class__: qcodes.instrument.parameter.ManualParameter
+        instrument: autodepgraph.node.CalibrationNode
+        instrument_name: A
+        label: parents
+        name: parents
+        ts: '2017-05-23 10:02:16'
+        unit: ''
+        vals: '<Lists : <Strings>>'
+        value: []
+      state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
+        instrument_name: A, label: state, name: state, ts: '2017-05-23 10:02:16',
+        unit: '', vals: '<Enum: {''unknown'', ''needs calibration'', ''active'', ''good'',
           ''bad''}>', value: good}
   B:
-    __class__: autodepgraph.graph.CalibrationNode
+    __class__: autodepgraph.node.CalibrationNode
     functions: {}
     name: B
     parameters:
-      IDN: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.graph.CalibrationNode,
+      IDN: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
         instrument_name: B, label: IDN, name: IDN, ts: null, unit: '', vals: <Anything>,
         value: null}
-      calibrate_functions: {__class__: qcodes.instrument.parameter.ManualParameter,
-        instrument: autodepgraph.graph.CalibrationNode, instrument_name: B, label: calibrate_functions,
-        name: calibrate_functions, ts: null, unit: '', vals: '<Lists : <Strings>>',
-        value: null}
-      check_functions: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.graph.CalibrationNode,
-        instrument_name: B, label: check_functions, name: check_functions, ts: null,
-        unit: '', vals: '<Lists : <Strings>>', value: null}
-      dependencies: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.graph.CalibrationNode,
-        instrument_name: B, label: dependencies, name: dependencies, ts: null, unit: '',
-        vals: '<Lists : <Strings>>', value: [A]}
-      state: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.graph.CalibrationNode,
-        instrument_name: B, label: state, name: state, ts: '2017-04-29 16:41:13',
-        unit: '', vals: '<Enum: {''good'', ''unknown'', ''active'', ''needs calibration'',
+      calibrate_functions:
+        __class__: qcodes.instrument.parameter.ManualParameter
+        instrument: autodepgraph.node.CalibrationNode
+        instrument_name: B
+        label: calibrate_functions
+        name: calibrate_functions
+        ts: '2017-05-23 10:02:16'
+        unit: ''
+        vals: '<Lists : <Strings>>'
+        value: []
+      calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
+        instrument: autodepgraph.node.CalibrationNode, instrument_name: B, label: calibration_timeout,
+        name: calibration_timeout, ts: '2017-05-23 10:02:16', unit: s, vals: <Numbers
+          v>=0>, value: .inf}
+      check_functions:
+        __class__: qcodes.instrument.parameter.ManualParameter
+        instrument: autodepgraph.node.CalibrationNode
+        instrument_name: B
+        label: check_functions
+        name: check_functions
+        ts: '2017-05-23 10:02:16'
+        unit: ''
+        vals: '<Lists : <Strings>>'
+        value: []
+      children:
+        __class__: qcodes.instrument.parameter.ManualParameter
+        instrument: autodepgraph.node.CalibrationNode
+        instrument_name: B
+        label: children
+        name: children
+        ts: '2017-05-23 10:02:16'
+        unit: ''
+        vals: '<Lists : <Strings>>'
+        value: []
+      parents:
+        __class__: qcodes.instrument.parameter.ManualParameter
+        instrument: autodepgraph.node.CalibrationNode
+        instrument_name: B
+        label: parents
+        name: parents
+        ts: '2017-05-23 10:02:16'
+        unit: ''
+        vals: '<Lists : <Strings>>'
+        value: []
+      state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
+        instrument_name: B, label: state, name: state, ts: '2017-05-23 10:02:16',
+        unit: '', vals: '<Enum: {''unknown'', ''needs calibration'', ''active'', ''good'',
           ''bad''}>', value: bad}
   E:
-    __class__: autodepgraph.graph.CalibrationNode
+    __class__: autodepgraph.node.CalibrationNode
     functions: {}
     name: E
     parameters:
-      IDN: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.graph.CalibrationNode,
+      IDN: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
         instrument_name: E, label: IDN, name: IDN, ts: null, unit: '', vals: <Anything>,
         value: null}
-      calibrate_functions: {__class__: qcodes.instrument.parameter.ManualParameter,
-        instrument: autodepgraph.graph.CalibrationNode, instrument_name: E, label: calibrate_functions,
-        name: calibrate_functions, ts: null, unit: '', vals: '<Lists : <Strings>>',
-        value: null}
-      check_functions: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.graph.CalibrationNode,
-        instrument_name: E, label: check_functions, name: check_functions, ts: null,
-        unit: '', vals: '<Lists : <Strings>>', value: null}
-      dependencies: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.graph.CalibrationNode,
-        instrument_name: E, label: dependencies, name: dependencies, ts: null, unit: '',
-        vals: '<Lists : <Strings>>', value: ['A']}
-      state: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.graph.CalibrationNode,
-        instrument_name: E, label: state, name: state, ts: '2017-04-29 16:41:13',
-        unit: '', vals: '<Enum: {''good'', ''unknown'', ''active'', ''needs calibration'',
+      calibrate_functions:
+        __class__: qcodes.instrument.parameter.ManualParameter
+        instrument: autodepgraph.node.CalibrationNode
+        instrument_name: E
+        label: calibrate_functions
+        name: calibrate_functions
+        ts: '2017-05-23 10:02:16'
+        unit: ''
+        vals: '<Lists : <Strings>>'
+        value: []
+      calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
+        instrument: autodepgraph.node.CalibrationNode, instrument_name: E, label: calibration_timeout,
+        name: calibration_timeout, ts: '2017-05-23 10:02:16', unit: s, vals: <Numbers
+          v>=0>, value: .inf}
+      check_functions:
+        __class__: qcodes.instrument.parameter.ManualParameter
+        instrument: autodepgraph.node.CalibrationNode
+        instrument_name: E
+        label: check_functions
+        name: check_functions
+        ts: '2017-05-23 10:02:16'
+        unit: ''
+        vals: '<Lists : <Strings>>'
+        value: []
+      children:
+        __class__: qcodes.instrument.parameter.ManualParameter
+        instrument: autodepgraph.node.CalibrationNode
+        instrument_name: E
+        label: children
+        name: children
+        ts: '2017-05-23 10:02:16'
+        unit: ''
+        vals: '<Lists : <Strings>>'
+        value: []
+      parents:
+        __class__: qcodes.instrument.parameter.ManualParameter
+        instrument: autodepgraph.node.CalibrationNode
+        instrument_name: E
+        label: parents
+        name: parents
+        ts: '2017-05-23 10:02:16'
+        unit: ''
+        vals: '<Lists : <Strings>>'
+        value: []
+      state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
+        instrument_name: E, label: state, name: state, ts: '2017-05-23 10:02:16',
+        unit: '', vals: '<Enum: {''unknown'', ''needs calibration'', ''active'', ''good'',
           ''bad''}>', value: unknown}
   F:
-    __class__: autodepgraph.graph.CalibrationNode
+    __class__: autodepgraph.node.CalibrationNode
     functions: {}
     name: F
     parameters:
-      IDN: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.graph.CalibrationNode,
+      IDN: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
         instrument_name: F, label: IDN, name: IDN, ts: null, unit: '', vals: <Anything>,
         value: null}
-      calibrate_functions: {__class__: qcodes.instrument.parameter.ManualParameter,
-        instrument: autodepgraph.graph.CalibrationNode, instrument_name: F, label: calibrate_functions,
-        name: calibrate_functions, ts: null, unit: '', vals: '<Lists : <Strings>>',
-        value: null}
-      check_functions: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.graph.CalibrationNode,
-        instrument_name: F, label: check_functions, name: check_functions, ts: null,
-        unit: '', vals: '<Lists : <Strings>>', value: null}
-      dependencies: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.graph.CalibrationNode,
-        instrument_name: F, label: dependencies, name: dependencies, ts: null, unit: '',
-        vals: '<Lists : <Strings>>', value: null}
-      state: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.graph.CalibrationNode,
-        instrument_name: F, label: state, name: state, ts: '2017-04-29 16:41:13',
-        unit: '', vals: '<Enum: {''good'', ''unknown'', ''active'', ''needs calibration'',
+      calibrate_functions:
+        __class__: qcodes.instrument.parameter.ManualParameter
+        instrument: autodepgraph.node.CalibrationNode
+        instrument_name: F
+        label: calibrate_functions
+        name: calibrate_functions
+        ts: '2017-05-23 10:02:16'
+        unit: ''
+        vals: '<Lists : <Strings>>'
+        value: []
+      calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
+        instrument: autodepgraph.node.CalibrationNode, instrument_name: F, label: calibration_timeout,
+        name: calibration_timeout, ts: '2017-05-23 10:02:16', unit: s, vals: <Numbers
+          v>=0>, value: .inf}
+      check_functions:
+        __class__: qcodes.instrument.parameter.ManualParameter
+        instrument: autodepgraph.node.CalibrationNode
+        instrument_name: F
+        label: check_functions
+        name: check_functions
+        ts: '2017-05-23 10:02:16'
+        unit: ''
+        vals: '<Lists : <Strings>>'
+        value: []
+      children:
+        __class__: qcodes.instrument.parameter.ManualParameter
+        instrument: autodepgraph.node.CalibrationNode
+        instrument_name: F
+        label: children
+        name: children
+        ts: '2017-05-23 10:02:16'
+        unit: ''
+        vals: '<Lists : <Strings>>'
+        value: []
+      parents:
+        __class__: qcodes.instrument.parameter.ManualParameter
+        instrument: autodepgraph.node.CalibrationNode
+        instrument_name: F
+        label: parents
+        name: parents
+        ts: '2017-05-23 10:02:16'
+        unit: ''
+        vals: '<Lists : <Strings>>'
+        value: []
+      state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
+        instrument_name: F, label: state, name: state, ts: '2017-05-23 10:02:16',
+        unit: '', vals: '<Enum: {''unknown'', ''needs calibration'', ''active'', ''good'',
           ''bad''}>', value: unknown}

--- a/autodepgraph/tests/test_data/test_graph_states.yaml
+++ b/autodepgraph/tests/test_data/test_graph_states.yaml
@@ -14,34 +14,48 @@ nodes:
         instrument_name: A
         label: calibrate_functions
         name: calibrate_functions
-        ts: '2017-04-30 22:13:50'
+        ts: '2017-05-23 10:02:16'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
+      calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
+        instrument: autodepgraph.node.CalibrationNode, instrument_name: A, label: calibration_timeout,
+        name: calibration_timeout, ts: '2017-05-23 10:02:16', unit: s, vals: <Numbers
+          v>=0>, value: .inf}
       check_functions:
         __class__: qcodes.instrument.parameter.ManualParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: A
         label: check_functions
         name: check_functions
-        ts: '2017-04-30 22:13:50'
+        ts: '2017-05-23 10:02:16'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
-      dependencies:
+      children:
         __class__: qcodes.instrument.parameter.ManualParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: A
-        label: dependencies
-        name: dependencies
-        ts: '2017-04-30 22:13:50'
+        label: children
+        name: children
+        ts: '2017-05-23 10:02:16'
+        unit: ''
+        vals: '<Lists : <Strings>>'
+        value: [D, B]
+      parents:
+        __class__: qcodes.instrument.parameter.ManualParameter
+        instrument: autodepgraph.node.CalibrationNode
+        instrument_name: A
+        label: parents
+        name: parents
+        ts: '2017-05-23 10:02:16'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
-      state: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: A, label: state, name: state, ts: '2017-04-30 22:47:24',
-        unit: '', vals: '<Enum: {''bad'', ''needs calibration'', ''active'', ''good'',
-          ''unknown''}>', value: good}
+      state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
+        instrument_name: A, label: state, name: state, ts: '2017-05-23 10:02:16',
+        unit: '', vals: '<Enum: {''unknown'', ''needs calibration'', ''active'', ''good'',
+          ''bad''}>', value: unknown}
   B:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -56,34 +70,48 @@ nodes:
         instrument_name: B
         label: calibrate_functions
         name: calibrate_functions
-        ts: '2017-04-30 22:13:50'
+        ts: '2017-05-23 10:02:16'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
+      calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
+        instrument: autodepgraph.node.CalibrationNode, instrument_name: B, label: calibration_timeout,
+        name: calibration_timeout, ts: '2017-05-23 10:02:16', unit: s, vals: <Numbers
+          v>=0>, value: .inf}
       check_functions:
         __class__: qcodes.instrument.parameter.ManualParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: B
         label: check_functions
         name: check_functions
-        ts: '2017-04-30 22:13:50'
+        ts: '2017-05-23 10:02:16'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
-      dependencies:
+      children:
         __class__: qcodes.instrument.parameter.ManualParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: B
-        label: dependencies
-        name: dependencies
-        ts: '2017-04-30 22:13:57'
+        label: children
+        name: children
+        ts: '2017-05-23 10:02:16'
+        unit: ''
+        vals: '<Lists : <Strings>>'
+        value: [C]
+      parents:
+        __class__: qcodes.instrument.parameter.ManualParameter
+        instrument: autodepgraph.node.CalibrationNode
+        instrument_name: B
+        label: parents
+        name: parents
+        ts: '2017-05-23 10:02:16'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [A]
-      state: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: B, label: state, name: state, ts: '2017-04-30 22:47:24',
-        unit: '', vals: '<Enum: {''bad'', ''needs calibration'', ''active'', ''good'',
-          ''unknown''}>', value: active}
+      state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
+        instrument_name: B, label: state, name: state, ts: '2017-05-23 10:02:16',
+        unit: '', vals: '<Enum: {''unknown'', ''needs calibration'', ''active'', ''good'',
+          ''bad''}>', value: unknown}
   C:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -98,34 +126,48 @@ nodes:
         instrument_name: C
         label: calibrate_functions
         name: calibrate_functions
-        ts: '2017-04-30 22:48:54'
+        ts: '2017-05-23 10:02:16'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
+      calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
+        instrument: autodepgraph.node.CalibrationNode, instrument_name: C, label: calibration_timeout,
+        name: calibration_timeout, ts: '2017-05-23 10:02:16', unit: s, vals: <Numbers
+          v>=0>, value: .inf}
       check_functions:
         __class__: qcodes.instrument.parameter.ManualParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: C
         label: check_functions
         name: check_functions
-        ts: '2017-04-30 22:48:54'
+        ts: '2017-05-23 10:02:16'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
-      dependencies:
+      children:
         __class__: qcodes.instrument.parameter.ManualParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: C
-        label: dependencies
-        name: dependencies
-        ts: '2017-04-30 22:51:52'
+        label: children
+        name: children
+        ts: '2017-05-23 10:02:16'
+        unit: ''
+        vals: '<Lists : <Strings>>'
+        value: [D]
+      parents:
+        __class__: qcodes.instrument.parameter.ManualParameter
+        instrument: autodepgraph.node.CalibrationNode
+        instrument_name: C
+        label: parents
+        name: parents
+        ts: '2017-05-23 10:02:16'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [B]
-      state: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: C, label: state, name: state, ts: '2017-04-30 22:48:54',
-        unit: '', vals: '<Enum: {''bad'', ''needs calibration'', ''active'', ''good'',
-          ''unknown''}>', value: unknown}
+      state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
+        instrument_name: C, label: state, name: state, ts: '2017-05-23 10:02:16',
+        unit: '', vals: '<Enum: {''unknown'', ''needs calibration'', ''active'', ''good'',
+          ''bad''}>', value: unknown}
   D:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -140,34 +182,48 @@ nodes:
         instrument_name: D
         label: calibrate_functions
         name: calibrate_functions
-        ts: '2017-04-30 22:49:27'
+        ts: '2017-05-23 10:02:16'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
+      calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
+        instrument: autodepgraph.node.CalibrationNode, instrument_name: D, label: calibration_timeout,
+        name: calibration_timeout, ts: '2017-05-23 10:02:16', unit: s, vals: <Numbers
+          v>=0>, value: .inf}
       check_functions:
         __class__: qcodes.instrument.parameter.ManualParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: D
         label: check_functions
         name: check_functions
-        ts: '2017-04-30 22:49:27'
+        ts: '2017-05-23 10:02:16'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
-      dependencies:
+      children:
         __class__: qcodes.instrument.parameter.ManualParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: D
-        label: dependencies
-        name: dependencies
-        ts: '2017-04-30 22:51:25'
+        label: children
+        name: children
+        ts: '2017-05-23 10:02:16'
+        unit: ''
+        vals: '<Lists : <Strings>>'
+        value: [E, G]
+      parents:
+        __class__: qcodes.instrument.parameter.ManualParameter
+        instrument: autodepgraph.node.CalibrationNode
+        instrument_name: D
+        label: parents
+        name: parents
+        ts: '2017-05-23 10:02:16'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [C, A]
-      state: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: D, label: state, name: state, ts: '2017-04-30 22:49:27',
-        unit: '', vals: '<Enum: {''bad'', ''needs calibration'', ''active'', ''good'',
-          ''unknown''}>', value: unknown}
+      state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
+        instrument_name: D, label: state, name: state, ts: '2017-05-23 10:02:16',
+        unit: '', vals: '<Enum: {''unknown'', ''needs calibration'', ''active'', ''good'',
+          ''bad''}>', value: unknown}
   E:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -182,34 +238,48 @@ nodes:
         instrument_name: E
         label: calibrate_functions
         name: calibrate_functions
-        ts: '2017-04-30 22:13:50'
+        ts: '2017-05-23 10:02:16'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
+      calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
+        instrument: autodepgraph.node.CalibrationNode, instrument_name: E, label: calibration_timeout,
+        name: calibration_timeout, ts: '2017-05-23 10:02:16', unit: s, vals: <Numbers
+          v>=0>, value: .inf}
       check_functions:
         __class__: qcodes.instrument.parameter.ManualParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: E
         label: check_functions
         name: check_functions
-        ts: '2017-04-30 22:13:50'
+        ts: '2017-05-23 10:02:16'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
-      dependencies:
+      children:
         __class__: qcodes.instrument.parameter.ManualParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: E
-        label: dependencies
-        name: dependencies
-        ts: '2017-04-30 22:51:25'
+        label: children
+        name: children
+        ts: '2017-05-23 10:02:16'
+        unit: ''
+        vals: '<Lists : <Strings>>'
+        value: []
+      parents:
+        __class__: qcodes.instrument.parameter.ManualParameter
+        instrument: autodepgraph.node.CalibrationNode
+        instrument_name: E
+        label: parents
+        name: parents
+        ts: '2017-05-23 10:02:16'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [D]
-      state: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: E, label: state, name: state, ts: '2017-04-30 23:01:47',
-        unit: '', vals: '<Enum: {''bad'', ''needs calibration'', ''active'', ''good'',
-          ''unknown''}>', value: bad}
+      state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
+        instrument_name: E, label: state, name: state, ts: '2017-05-23 10:02:16',
+        unit: '', vals: '<Enum: {''unknown'', ''needs calibration'', ''active'', ''good'',
+          ''bad''}>', value: unknown}
   F:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -224,34 +294,48 @@ nodes:
         instrument_name: F
         label: calibrate_functions
         name: calibrate_functions
-        ts: '2017-04-30 22:13:50'
+        ts: '2017-05-23 10:02:16'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
+      calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
+        instrument: autodepgraph.node.CalibrationNode, instrument_name: F, label: calibration_timeout,
+        name: calibration_timeout, ts: '2017-05-23 10:02:16', unit: s, vals: <Numbers
+          v>=0>, value: .inf}
       check_functions:
         __class__: qcodes.instrument.parameter.ManualParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: F
         label: check_functions
         name: check_functions
-        ts: '2017-04-30 22:13:50'
+        ts: '2017-05-23 10:02:16'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
-      dependencies:
+      children:
         __class__: qcodes.instrument.parameter.ManualParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: F
-        label: dependencies
-        name: dependencies
-        ts: '2017-04-30 22:13:50'
+        label: children
+        name: children
+        ts: '2017-05-23 10:02:16'
+        unit: ''
+        vals: '<Lists : <Strings>>'
+        value: [G]
+      parents:
+        __class__: qcodes.instrument.parameter.ManualParameter
+        instrument: autodepgraph.node.CalibrationNode
+        instrument_name: F
+        label: parents
+        name: parents
+        ts: '2017-05-23 10:02:16'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
-      state: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: F, label: state, name: state, ts: '2017-04-30 22:47:24',
-        unit: '', vals: '<Enum: {''bad'', ''needs calibration'', ''active'', ''good'',
-          ''unknown''}>', value: needs calibration}
+      state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
+        instrument_name: F, label: state, name: state, ts: '2017-05-23 10:02:16',
+        unit: '', vals: '<Enum: {''unknown'', ''needs calibration'', ''active'', ''good'',
+          ''bad''}>', value: unknown}
   G:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -266,34 +350,48 @@ nodes:
         instrument_name: G
         label: calibrate_functions
         name: calibrate_functions
-        ts: '2017-04-30 22:49:27'
+        ts: '2017-05-23 10:02:16'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
+      calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
+        instrument: autodepgraph.node.CalibrationNode, instrument_name: G, label: calibration_timeout,
+        name: calibration_timeout, ts: '2017-05-23 10:02:16', unit: s, vals: <Numbers
+          v>=0>, value: .inf}
       check_functions:
         __class__: qcodes.instrument.parameter.ManualParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: G
         label: check_functions
         name: check_functions
-        ts: '2017-04-30 22:49:27'
+        ts: '2017-05-23 10:02:16'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
-      dependencies:
+      children:
         __class__: qcodes.instrument.parameter.ManualParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: G
-        label: dependencies
-        name: dependencies
-        ts: '2017-04-30 22:51:25'
+        label: children
+        name: children
+        ts: '2017-05-23 10:02:16'
+        unit: ''
+        vals: '<Lists : <Strings>>'
+        value: [H]
+      parents:
+        __class__: qcodes.instrument.parameter.ManualParameter
+        instrument: autodepgraph.node.CalibrationNode
+        instrument_name: G
+        label: parents
+        name: parents
+        ts: '2017-05-23 10:02:16'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [F, D]
-      state: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: G, label: state, name: state, ts: '2017-04-30 22:49:27',
-        unit: '', vals: '<Enum: {''bad'', ''needs calibration'', ''active'', ''good'',
-          ''unknown''}>', value: unknown}
+      state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
+        instrument_name: G, label: state, name: state, ts: '2017-05-23 10:02:16',
+        unit: '', vals: '<Enum: {''unknown'', ''needs calibration'', ''active'', ''good'',
+          ''bad''}>', value: unknown}
   H:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -308,31 +406,45 @@ nodes:
         instrument_name: H
         label: calibrate_functions
         name: calibrate_functions
-        ts: '2017-04-30 22:49:27'
+        ts: '2017-05-23 10:02:16'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
+      calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
+        instrument: autodepgraph.node.CalibrationNode, instrument_name: H, label: calibration_timeout,
+        name: calibration_timeout, ts: '2017-05-23 10:02:16', unit: s, vals: <Numbers
+          v>=0>, value: .inf}
       check_functions:
         __class__: qcodes.instrument.parameter.ManualParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: H
         label: check_functions
         name: check_functions
-        ts: '2017-04-30 22:49:27'
+        ts: '2017-05-23 10:02:16'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
-      dependencies:
+      children:
         __class__: qcodes.instrument.parameter.ManualParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: H
-        label: dependencies
-        name: dependencies
-        ts: '2017-04-30 22:51:25'
+        label: children
+        name: children
+        ts: '2017-05-23 10:02:16'
+        unit: ''
+        vals: '<Lists : <Strings>>'
+        value: []
+      parents:
+        __class__: qcodes.instrument.parameter.ManualParameter
+        instrument: autodepgraph.node.CalibrationNode
+        instrument_name: H
+        label: parents
+        name: parents
+        ts: '2017-05-23 10:02:16'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [G]
-      state: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: H, label: state, name: state, ts: '2017-04-30 22:49:27',
-        unit: '', vals: '<Enum: {''bad'', ''needs calibration'', ''active'', ''good'',
-          ''unknown''}>', value: unknown}
+      state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
+        instrument_name: H, label: state, name: state, ts: '2017-05-23 10:02:16',
+        unit: '', vals: '<Enum: {''unknown'', ''needs calibration'', ''active'', ''good'',
+          ''bad''}>', value: unknown}

--- a/autodepgraph/tests/test_graph.py
+++ b/autodepgraph/tests/test_graph.py
@@ -44,7 +44,6 @@ class Test_Graph(TestCase):
         # reset all edges
         for i in [self.node_A, self.node_B, self.node_C, self.node_D]:
             i.parents([])
-            i.children([])
 
         self.node_A.add_parent('B')
         self.node_A.add_parent('D')

--- a/autodepgraph/tests/test_graph.py
+++ b/autodepgraph/tests/test_graph.py
@@ -40,6 +40,41 @@ class Test_Graph(TestCase):
         nodes_after = test_graph.nodes.keys()
         self.assertEqual(nodes_after, set(['A', 'B', 'E']))
 
+    def test_add_remove_edges(self):
+        # reset all edges
+        for i in [self.node_A, self.node_B, self.node_C, self.node_D]:
+            i.parents([])
+            i.children([])
+
+        self.node_A.add_parent('B')
+        self.node_A.add_parent('D')
+        self.node_C.add_child('D')
+        self.node_D.add_parent('B')
+
+        self.assertEqual(self.node_A.parents(), ['B', 'D'])
+        self.assertEqual(self.node_A.children(), [])
+        self.assertEqual(self.node_B.parents(), [])
+        self.assertEqual(self.node_B.children(), ['A', 'D'])
+        self.assertEqual(self.node_C.parents(), [])
+        self.assertEqual(self.node_C.children(), ['D'])
+        self.assertEqual(self.node_D.parents(), ['C', 'B'])
+        self.assertEqual(self.node_D.children(), [])
+
+        self.node_A.remove_parent('B')
+        self.node_A.remove_parent('D')
+        self.node_C.remove_child('D')
+        self.node_B.remove_child('B')
+
+        self.assertEqual(self.node_A.parents(), [])
+        self.assertEqual(self.node_B.parents(), [])
+        self.assertEqual(self.node_C.parents(), [])
+        self.assertEqual(self.node_D.parents(), [])
+
+        self.assertEqual(self.node_A.children(), [])
+        self.assertEqual(self.node_B.children(), [])
+        self.assertEqual(self.node_C.children(), [])
+        self.assertEqual(self.node_D.children(), [])
+
     def test_save_graph(self):
         test_graph = Graph('test_graph_saving')
 

--- a/autodepgraph/tests/test_graph.py
+++ b/autodepgraph/tests/test_graph.py
@@ -58,12 +58,12 @@ class Test_Graph(TestCase):
         self.assertEqual(self.node_C.parents(), [])
         self.assertEqual(self.node_C.children(), ['D'])
         self.assertEqual(self.node_D.parents(), ['C', 'B'])
-        self.assertEqual(self.node_D.children(), [])
+        self.assertEqual(self.node_D.children(), ['A'])
 
         self.node_A.remove_parent('B')
         self.node_A.remove_parent('D')
         self.node_C.remove_child('D')
-        self.node_B.remove_child('B')
+        self.node_B.remove_child('D')
 
         self.assertEqual(self.node_A.parents(), [])
         self.assertEqual(self.node_B.parents(), [])

--- a/autodepgraph/tests/test_graph.py
+++ b/autodepgraph/tests/test_graph.py
@@ -48,7 +48,7 @@ class Test_Graph(TestCase):
 
         self.node_A.add_parent('B')
         self.node_A.add_parent('D')
-        self.node_C.add_child('D')
+        self.node_D.add_parent('C')
         self.node_D.add_parent('B')
 
         self.assertEqual(self.node_A.parents(), ['B', 'D'])
@@ -62,8 +62,8 @@ class Test_Graph(TestCase):
 
         self.node_A.remove_parent('B')
         self.node_A.remove_parent('D')
-        self.node_C.remove_child('D')
-        self.node_B.remove_child('D')
+        self.node_D.remove_parent('C')
+        self.node_D.remove_parent('B')
 
         self.assertEqual(self.node_A.parents(), [])
         self.assertEqual(self.node_B.parents(), [])

--- a/autodepgraph/tests/test_logic.py
+++ b/autodepgraph/tests/test_logic.py
@@ -23,9 +23,9 @@ class Test_GraphLogic(TestCase):
         self.dummy_graph.add_node(self.node_c)
 
         # Link the nodes
-        self.node_a.dependencies(['B', 'C'])
-        self.node_b.dependencies(['C'])
-        self.node_c.dependencies([])
+        self.node_a.parents(['B', 'C'])
+        self.node_b.parents(['C'])
+        self.node_c.parents([])
 
         # Populate nodes with checks and calibration functions
         self.node_a.check_functions()

--- a/autodepgraph/tests/test_logic.py
+++ b/autodepgraph/tests/test_logic.py
@@ -238,6 +238,20 @@ class Test_GraphLogic(TestCase):
         with self.assertRaises(AttributeError):
             node_d()
 
+    def test_error_propagation(self):
+        self.node_c.state('good')
+        self.node_b.propagate_error('bad')
+
+        self.assertEqual(self.node_a.state(), 'bad')
+        self.assertEqual(self.node_b.state(), 'bad')
+        self.assertEqual(self.node_c.state(), 'good')
+
+        self.node_c.propagate_error('unknown')
+
+        self.assertEqual(self.node_a.state(), 'unknown')
+        self.assertEqual(self.node_b.state(), 'unknown')
+        self.assertEqual(self.node_c.state(), 'unknown')
+
     @classmethod
     def tearDownClass(self):
         # finds and closes all qcodes instruments

--- a/autodepgraph/tests/write_test_graphs.py
+++ b/autodepgraph/tests/write_test_graphs.py
@@ -3,6 +3,11 @@ import autodepgraph.graph as g
 import autodepgraph.node as n
 import os
 
+############################################
+# This file generates and saves predefined
+# graphs used in the tests.
+############################################
+
 test_dir = os.path.join(adg.__path__[0], 'tests', 'test_data')
 
 # Write graph for test_graph

--- a/autodepgraph/tests/write_test_graphs.py
+++ b/autodepgraph/tests/write_test_graphs.py
@@ -1,7 +1,6 @@
 import autodepgraph as adg
 import autodepgraph.graph as g
 import autodepgraph.node as n
-import autodepgraph.visualization as v
 import os
 
 test_dir = os.path.join(adg.__path__[0], 'tests', 'test_data')

--- a/autodepgraph/tests/write_test_graphs.py
+++ b/autodepgraph/tests/write_test_graphs.py
@@ -1,0 +1,58 @@
+import autodepgraph as adg
+import autodepgraph.graph as g
+import autodepgraph.node as n
+import autodepgraph.visualization as v
+import os
+
+test_dir = os.path.join(adg.__path__[0], 'tests', 'test_data')
+
+# Write graph for test_graph
+
+nodeA = n.CalibrationNode('A')
+nodeB = n.CalibrationNode('B')
+nodeE = n.CalibrationNode('E')
+nodeF = n.CalibrationNode('F')
+
+a = g.Graph('new_graph')
+a.add_node(nodeA)
+a.add_node(nodeB)
+a.add_node(nodeE)
+a.add_node(nodeF)
+
+nodeA.state('good')
+nodeB.state('bad')
+nodeE.state('unknown')
+
+a.save_graph(os.path.join(test_dir, 'test_graph_new_nodes.yaml'))
+
+# Write graph for test_visualization
+
+nodeC = n.CalibrationNode('C')
+nodeD = n.CalibrationNode('D')
+nodeG = n.CalibrationNode('G')
+nodeH = n.CalibrationNode('H')
+
+a.add_node('C')
+a.add_node('D')
+a.add_node('G')
+a.add_node('H')
+
+nodeA.state('unknown')
+nodeB.state('unknown')
+nodeE.state('unknown')
+
+nodeD.add_parent('C')
+nodeD.add_parent('A')
+nodeE.add_parent('D')
+nodeG.add_parent('F')
+nodeC.add_parent('B')
+nodeB.add_parent('A')
+nodeG.add_parent('D')
+nodeH.add_parent('G')
+
+a.save_graph(os.path.join(test_dir, 'test_graph_states.yaml'))
+
+for node in a.nodes.values():
+    node.close()
+
+a.close()

--- a/autodepgraph/visualization.py
+++ b/autodepgraph/visualization.py
@@ -33,7 +33,7 @@ def snapshot_to_nxGraph(snapshot):
     nxG = nx.DiGraph()
     nxG.add_nodes_from(g_snap)
     for node_name, n_snap in g_snap.items():
-        for dependency in n_snap['parameters']['dependencies']['value']:
+        for dependency in n_snap['parameters']['parents']['value']:
             nxG.add_edge(node_name, dependency)
     return nxG
 

--- a/examples/Example notebook.ipynb
+++ b/examples/Example notebook.ipynb
@@ -2,7 +2,10 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "\n",
     "# Example notebook\n",
@@ -18,7 +21,9 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -40,7 +45,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Creatinga custom graph\n",
     "A graph can be instantiated"
@@ -50,7 +58,9 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -62,29 +72,35 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
-    "Set the dependencies as a list of nodenames"
+    "Set the dependencies as a list of nodenames. The nodes which a node `A` depends on are called `A.parents()`. The nodes which depend on a node `B` are called `B.children()`."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
-    "\n",
-    "test_graph.C.dependencies(['A', 'B'])\n",
-    "test_graph.B.dependencies(['A'])"
+    "test_graph.C.parents(['A', 'B'])\n",
+    "test_graph.B.parents(['A'])"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -103,7 +119,9 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -117,7 +135,9 @@
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -130,6 +150,8 @@
    "execution_count": 7,
    "metadata": {
     "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "scrolled": false
    },
    "outputs": [
@@ -175,7 +197,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Rabi model calibrations example\n",
     "\n",
@@ -186,7 +211,9 @@
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -198,7 +225,9 @@
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -212,16 +241,21 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### The layout can be changed by resetting the node pos"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -231,16 +265,21 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Reset the state of all nodes"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -252,9 +291,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -296,7 +337,7 @@
        "'good'"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -307,16 +348,21 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## We can also artificially break one of the nodes and see how the calibration recovers"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 15,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -335,9 +381,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 16,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -348,9 +396,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 17,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -359,7 +409,7 @@
        "'good'"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -370,9 +420,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 18,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -381,7 +433,7 @@
        "'good'"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -389,6 +441,15 @@
    "source": [
     "rmg.High_readout_fidelity()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -407,7 +468,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.6.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This resolves #18. 
Error propagation from a broken node to nodes that depend on it is made possible. For this a new parameter `children` is added to the node structure (`dependencies` has been renamed `parents` to be consistent), which contains a list of all nodes that depend on this node. The new `add_parent` and `remove_parent` methods take care of adding and removing references in the `children` lists of other nodes where needed, meaning that the `children` should never have to be edited manually. Additionally, the `close` method is overridden to remove a node from the `children` of its parents when it is deleted.