### PR TITLE
Enh/node symbol

### DIFF
--- a/autodepgraph/graph.py
+++ b/autodepgraph/graph.py
@@ -122,7 +122,7 @@ class Graph(Instrument):
             # ensures states are updated before taking snapshot
             node.state()
         self._node_pos = vis.draw_graph_mpl(
-            self.snapshot(), pos=self._node_pos, layout='spring')
+            self.snapshot(), pos=self._node_pos)
         plt.draw()
         plt.pause(.05)
 

--- a/autodepgraph/graph.py
+++ b/autodepgraph/graph.py
@@ -23,6 +23,7 @@ class Graph(Instrument):
         super().__init__(name)
         self.plot_mode = plot_mode
         self.nodes = {}
+        self._graph_changed_since_plot = False
 
     def load_graph(self, filename, load_node_state=False):
         """
@@ -96,9 +97,11 @@ class Graph(Instrument):
         node._parenth_graph = self.name
         self.nodes[node.name] = node
 
-        # Clears the node positions used for plotting when a new node is added
+        # Clears the node positions used for mpl plotting when a new node
+        # is added
         self._node_pos = None
-        # convenient for when adding nodes using name only
+        self._graph_changed_since_plot = True
+
         return node
 
     def clear_node_state(self):
@@ -132,5 +135,8 @@ class Graph(Instrument):
         for node in self.nodes.values():
             # ensures states are updated before taking snapshot
             node.state()
+        if self._graph_changed_since_plot and self.DiGraphWindow is not None:
+            self.DiGraphWindow.clear()
         self.DiGraphWindow = vis.draw_graph_pyqt(
             self.snapshot(), DiGraphWindow=self.DiGraphWindow)
+        self._graph_changed_since_plot = False

--- a/autodepgraph/graph.py
+++ b/autodepgraph/graph.py
@@ -138,5 +138,6 @@ class Graph(Instrument):
         if self._graph_changed_since_plot and self.DiGraphWindow is not None:
             self.DiGraphWindow.clear()
         self.DiGraphWindow = vis.draw_graph_pyqt(
-            self.snapshot(), DiGraphWindow=self.DiGraphWindow)
+            self.snapshot(), DiGraphWindow=self.DiGraphWindow,
+            window_title=self.name)
         self._graph_changed_since_plot = False

--- a/autodepgraph/node.py
+++ b/autodepgraph/node.py
@@ -300,6 +300,7 @@ class CalibrationNode(Instrument):
             result = (f() and result)
         except Exception as e:
             self.state('bad')
+            self.update_graph_monitor()
             raise e
 
         if verbose:

--- a/autodepgraph/tests/test_data/rabi_sims_example_graph.yaml
+++ b/autodepgraph/tests/test_data/rabi_sims_example_graph.yaml
@@ -10,22 +10,22 @@ nodes:
         vals: <Anything>, value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: Amplitude_coarse,
-        label: calibrate_function, name: calibrate_function, ts: '2017-05-28 15:03:52',
+        label: calibrate_function, name: calibrate_function, ts: '2017-06-04 14:24:22',
         unit: '', vals: <Strings>, value: test_calibration_True}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: Amplitude_coarse,
-        label: calibration_timeout, name: calibration_timeout, ts: '2017-05-28 15:03:52',
+        label: calibration_timeout, name: calibration_timeout, ts: '2017-06-04 14:24:22',
         unit: s, vals: <Numbers v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
         instrument_name: Amplitude_coarse, label: check_function, name: check_function,
-        ts: '2017-05-28 15:03:52', unit: '', vals: <Strings>, value: always_needs_calibration}
+        ts: '2017-06-04 14:24:22', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: Amplitude_coarse
         label: children
         name: children
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [SSRO, frequency_ramsey, Motzoi]
@@ -35,14 +35,14 @@ nodes:
         instrument_name: Amplitude_coarse
         label: parents
         name: parents
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [frequency_spec, mixer_offset, mixer_skewness]
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: Amplitude_coarse, label: state, name: state, ts: '2017-05-28
-          15:03:52', unit: '', vals: '<Enum: {''unknown'', ''bad'', ''good'', ''needs
-          calibration'', ''active''}>', value: unknown}
+        instrument_name: Amplitude_coarse, label: state, name: state, ts: '2017-06-04
+          14:24:22', unit: '', vals: '<Enum: {''active'', ''good'', ''unknown'', ''bad'',
+          ''needs calibration''}>', value: unknown}
   Amplitude_fine:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -53,22 +53,22 @@ nodes:
         vals: <Anything>, value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: Amplitude_fine,
-        label: calibrate_function, name: calibrate_function, ts: '2017-05-28 15:03:52',
+        label: calibrate_function, name: calibrate_function, ts: '2017-06-04 14:24:22',
         unit: '', vals: <Strings>, value: test_calibration_True}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: Amplitude_fine,
-        label: calibration_timeout, name: calibration_timeout, ts: '2017-05-28 15:03:52',
+        label: calibration_timeout, name: calibration_timeout, ts: '2017-06-04 14:24:22',
         unit: s, vals: <Numbers v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
         instrument_name: Amplitude_fine, label: check_function, name: check_function,
-        ts: '2017-05-28 15:03:52', unit: '', vals: <Strings>, value: always_needs_calibration}
+        ts: '2017-06-04 14:24:22', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: Amplitude_fine
         label: children
         name: children
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [High_fidelity_single_qubit_gates]
@@ -78,14 +78,14 @@ nodes:
         instrument_name: Amplitude_fine
         label: parents
         name: parents
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [Motzoi]
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: Amplitude_fine, label: state, name: state, ts: '2017-05-28
-          15:03:52', unit: '', vals: '<Enum: {''unknown'', ''bad'', ''good'', ''needs
-          calibration'', ''active''}>', value: unknown}
+        instrument_name: Amplitude_fine, label: state, name: state, ts: '2017-06-04
+          14:24:22', unit: '', vals: '<Enum: {''active'', ''good'', ''unknown'', ''bad'',
+          ''needs calibration''}>', value: unknown}
   Chevron_amp:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -96,22 +96,22 @@ nodes:
         value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: Chevron_amp,
-        label: calibrate_function, name: calibrate_function, ts: '2017-05-28 15:03:52',
+        label: calibrate_function, name: calibrate_function, ts: '2017-06-04 14:24:22',
         unit: '', vals: <Strings>, value: test_calibration_True}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: Chevron_amp,
-        label: calibration_timeout, name: calibration_timeout, ts: '2017-05-28 15:03:52',
+        label: calibration_timeout, name: calibration_timeout, ts: '2017-06-04 14:24:22',
         unit: s, vals: <Numbers v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
         instrument_name: Chevron_amp, label: check_function, name: check_function,
-        ts: '2017-05-28 15:03:52', unit: '', vals: <Strings>, value: always_needs_calibration}
+        ts: '2017-06-04 14:24:22', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: Chevron_amp
         label: children
         name: children
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [Trotter_chevron]
@@ -121,14 +121,14 @@ nodes:
         instrument_name: Chevron_amp
         label: parents
         name: parents
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [High_fidelity_single_qubit_gates, High_readout_fidelity]
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: Chevron_amp, label: state, name: state, ts: '2017-05-28 15:03:52',
-        unit: '', vals: '<Enum: {''unknown'', ''bad'', ''good'', ''needs calibration'',
-          ''active''}>', value: unknown}
+        instrument_name: Chevron_amp, label: state, name: state, ts: '2017-06-04 14:24:22',
+        unit: '', vals: '<Enum: {''active'', ''good'', ''unknown'', ''bad'', ''needs
+          calibration''}>', value: unknown}
   High_fidelity_single_qubit_gates:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -139,15 +139,15 @@ nodes:
         ts: null, unit: '', vals: <Anything>, value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: High_fidelity_single_qubit_gates,
-        label: calibrate_function, name: calibrate_function, ts: '2017-05-28 15:03:52',
+        label: calibrate_function, name: calibrate_function, ts: '2017-06-04 14:24:22',
         unit: '', vals: <Strings>, value: test_calibration_True}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: High_fidelity_single_qubit_gates,
-        label: calibration_timeout, name: calibration_timeout, ts: '2017-05-28 15:03:52',
+        label: calibration_timeout, name: calibration_timeout, ts: '2017-06-04 14:24:22',
         unit: s, vals: <Numbers v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
         instrument_name: High_fidelity_single_qubit_gates, label: check_function,
-        name: check_function, ts: '2017-05-28 15:03:52', unit: '', vals: <Strings>,
+        name: check_function, ts: '2017-06-04 14:24:22', unit: '', vals: <Strings>,
         value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
@@ -155,7 +155,7 @@ nodes:
         instrument_name: High_fidelity_single_qubit_gates
         label: children
         name: children
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [High_readout_fidelity, Chevron_amp, Rabi_simulation]
@@ -165,14 +165,14 @@ nodes:
         instrument_name: High_fidelity_single_qubit_gates
         label: parents
         name: parents
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [Amplitude_fine, Motzoi, frequency_ramsey]
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
         instrument_name: High_fidelity_single_qubit_gates, label: state, name: state,
-        ts: '2017-05-28 15:03:52', unit: '', vals: '<Enum: {''unknown'', ''bad'',
-          ''good'', ''needs calibration'', ''active''}>', value: unknown}
+        ts: '2017-06-04 14:24:22', unit: '', vals: '<Enum: {''active'', ''good'',
+          ''unknown'', ''bad'', ''needs calibration''}>', value: unknown}
   High_readout_fidelity:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -183,22 +183,22 @@ nodes:
         vals: <Anything>, value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: High_readout_fidelity,
-        label: calibrate_function, name: calibrate_function, ts: '2017-05-28 15:03:52',
+        label: calibrate_function, name: calibrate_function, ts: '2017-06-04 14:24:22',
         unit: '', vals: <Strings>, value: test_calibration_True}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: High_readout_fidelity,
-        label: calibration_timeout, name: calibration_timeout, ts: '2017-05-28 15:03:52',
+        label: calibration_timeout, name: calibration_timeout, ts: '2017-06-04 14:24:22',
         unit: s, vals: <Numbers v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
         instrument_name: High_readout_fidelity, label: check_function, name: check_function,
-        ts: '2017-05-28 15:03:52', unit: '', vals: <Strings>, value: always_needs_calibration}
+        ts: '2017-06-04 14:24:22', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: High_readout_fidelity
         label: children
         name: children
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [Chevron_amp, Rabi_simulation]
@@ -208,14 +208,14 @@ nodes:
         instrument_name: High_readout_fidelity
         label: parents
         name: parents
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [High_fidelity_single_qubit_gates, SSRO]
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: High_readout_fidelity, label: state, name: state, ts: '2017-05-28
-          15:03:52', unit: '', vals: '<Enum: {''unknown'', ''bad'', ''good'', ''needs
-          calibration'', ''active''}>', value: unknown}
+        instrument_name: High_readout_fidelity, label: state, name: state, ts: '2017-06-04
+          14:24:22', unit: '', vals: '<Enum: {''active'', ''good'', ''unknown'', ''bad'',
+          ''needs calibration''}>', value: unknown}
   Motzoi:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -226,22 +226,22 @@ nodes:
         value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: Motzoi, label: calibrate_function,
-        name: calibrate_function, ts: '2017-05-28 15:03:52', unit: '', vals: <Strings>,
+        name: calibrate_function, ts: '2017-06-04 14:24:22', unit: '', vals: <Strings>,
         value: test_calibration_True}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: Motzoi, label: calibration_timeout,
-        name: calibration_timeout, ts: '2017-05-28 15:03:52', unit: s, vals: <Numbers
+        name: calibration_timeout, ts: '2017-06-04 14:24:22', unit: s, vals: <Numbers
           v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: Motzoi, label: check_function, name: check_function, ts: '2017-05-28
-          15:03:52', unit: '', vals: <Strings>, value: always_needs_calibration}
+        instrument_name: Motzoi, label: check_function, name: check_function, ts: '2017-06-04
+          14:24:22', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: Motzoi
         label: children
         name: children
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [Amplitude_fine, High_fidelity_single_qubit_gates]
@@ -251,14 +251,14 @@ nodes:
         instrument_name: Motzoi
         label: parents
         name: parents
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [Amplitude_coarse, frequency_ramsey]
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: Motzoi, label: state, name: state, ts: '2017-05-28 15:03:52',
-        unit: '', vals: '<Enum: {''unknown'', ''bad'', ''good'', ''needs calibration'',
-          ''active''}>', value: unknown}
+        instrument_name: Motzoi, label: state, name: state, ts: '2017-06-04 14:24:22',
+        unit: '', vals: '<Enum: {''active'', ''good'', ''unknown'', ''bad'', ''needs
+          calibration''}>', value: unknown}
   Photon_meter:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -269,22 +269,22 @@ nodes:
         vals: <Anything>, value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: Photon_meter,
-        label: calibrate_function, name: calibrate_function, ts: '2017-05-28 15:03:52',
+        label: calibrate_function, name: calibrate_function, ts: '2017-06-04 14:24:22',
         unit: '', vals: <Strings>, value: test_calibration_True}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: Photon_meter,
-        label: calibration_timeout, name: calibration_timeout, ts: '2017-05-28 15:03:52',
+        label: calibration_timeout, name: calibration_timeout, ts: '2017-06-04 14:24:22',
         unit: s, vals: <Numbers v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
         instrument_name: Photon_meter, label: check_function, name: check_function,
-        ts: '2017-05-28 15:03:52', unit: '', vals: <Strings>, value: always_needs_calibration}
+        ts: '2017-06-04 14:24:22', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: Photon_meter
         label: children
         name: children
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [Wigner_tomography, Rabi_simulation]
@@ -294,14 +294,14 @@ nodes:
         instrument_name: Photon_meter
         label: parents
         name: parents
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [Trotter_chevron]
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: Photon_meter, label: state, name: state, ts: '2017-05-28
-          15:03:52', unit: '', vals: '<Enum: {''unknown'', ''bad'', ''good'', ''needs
-          calibration'', ''active''}>', value: unknown}
+        instrument_name: Photon_meter, label: state, name: state, ts: '2017-06-04
+          14:24:22', unit: '', vals: '<Enum: {''active'', ''good'', ''unknown'', ''bad'',
+          ''needs calibration''}>', value: unknown}
   Rabi_simulation:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -312,22 +312,22 @@ nodes:
         vals: <Anything>, value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: Rabi_simulation,
-        label: calibrate_function, name: calibrate_function, ts: '2017-05-28 15:03:52',
+        label: calibrate_function, name: calibrate_function, ts: '2017-06-04 14:24:22',
         unit: '', vals: <Strings>, value: test_calibration_True}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: Rabi_simulation,
-        label: calibration_timeout, name: calibration_timeout, ts: '2017-05-28 15:03:52',
+        label: calibration_timeout, name: calibration_timeout, ts: '2017-06-04 14:24:22',
         unit: s, vals: <Numbers v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
         instrument_name: Rabi_simulation, label: check_function, name: check_function,
-        ts: '2017-05-28 15:03:52', unit: '', vals: <Strings>, value: always_needs_calibration}
+        ts: '2017-06-04 14:24:22', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: Rabi_simulation
         label: children
         name: children
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
@@ -337,15 +337,15 @@ nodes:
         instrument_name: Rabi_simulation
         label: parents
         name: parents
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [Wigner_tomography, Photon_meter, High_fidelity_single_qubit_gates,
           High_readout_fidelity]
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: Rabi_simulation, label: state, name: state, ts: '2017-05-28
-          15:03:52', unit: '', vals: '<Enum: {''unknown'', ''bad'', ''good'', ''needs
-          calibration'', ''active''}>', value: unknown}
+        instrument_name: Rabi_simulation, label: state, name: state, ts: '2017-06-04
+          14:24:22', unit: '', vals: '<Enum: {''active'', ''good'', ''unknown'', ''bad'',
+          ''needs calibration''}>', value: unknown}
   SSRO:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -356,22 +356,22 @@ nodes:
         value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: SSRO, label: calibrate_function,
-        name: calibrate_function, ts: '2017-05-28 15:03:52', unit: '', vals: <Strings>,
+        name: calibrate_function, ts: '2017-06-04 14:24:22', unit: '', vals: <Strings>,
         value: test_calibration_True}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: SSRO, label: calibration_timeout,
-        name: calibration_timeout, ts: '2017-05-28 15:03:52', unit: s, vals: <Numbers
+        name: calibration_timeout, ts: '2017-06-04 14:24:22', unit: s, vals: <Numbers
           v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: SSRO, label: check_function, name: check_function, ts: '2017-05-28
-          15:03:52', unit: '', vals: <Strings>, value: always_needs_calibration}
+        instrument_name: SSRO, label: check_function, name: check_function, ts: '2017-06-04
+          14:24:22', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: SSRO
         label: children
         name: children
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [frequency_ramsey, High_readout_fidelity]
@@ -381,14 +381,14 @@ nodes:
         instrument_name: SSRO
         label: parents
         name: parents
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [Amplitude_coarse]
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: SSRO, label: state, name: state, ts: '2017-05-28 15:03:52',
-        unit: '', vals: '<Enum: {''unknown'', ''bad'', ''good'', ''needs calibration'',
-          ''active''}>', value: unknown}
+        instrument_name: SSRO, label: state, name: state, ts: '2017-06-04 14:24:22',
+        unit: '', vals: '<Enum: {''active'', ''good'', ''unknown'', ''bad'', ''needs
+          calibration''}>', value: unknown}
   Trotter_chevron:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -399,22 +399,22 @@ nodes:
         vals: <Anything>, value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: Trotter_chevron,
-        label: calibrate_function, name: calibrate_function, ts: '2017-05-28 15:03:52',
+        label: calibrate_function, name: calibrate_function, ts: '2017-06-04 14:24:22',
         unit: '', vals: <Strings>, value: test_calibration_True}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: Trotter_chevron,
-        label: calibration_timeout, name: calibration_timeout, ts: '2017-05-28 15:03:52',
+        label: calibration_timeout, name: calibration_timeout, ts: '2017-06-04 14:24:22',
         unit: s, vals: <Numbers v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
         instrument_name: Trotter_chevron, label: check_function, name: check_function,
-        ts: '2017-05-28 15:03:52', unit: '', vals: <Strings>, value: always_needs_calibration}
+        ts: '2017-06-04 14:24:22', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: Trotter_chevron
         label: children
         name: children
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [Photon_meter]
@@ -424,14 +424,14 @@ nodes:
         instrument_name: Trotter_chevron
         label: parents
         name: parents
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [Chevron_amp]
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: Trotter_chevron, label: state, name: state, ts: '2017-05-28
-          15:03:52', unit: '', vals: '<Enum: {''unknown'', ''bad'', ''good'', ''needs
-          calibration'', ''active''}>', value: unknown}
+        instrument_name: Trotter_chevron, label: state, name: state, ts: '2017-06-04
+          14:24:22', unit: '', vals: '<Enum: {''active'', ''good'', ''unknown'', ''bad'',
+          ''needs calibration''}>', value: unknown}
   Wigner_tomography:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -442,22 +442,22 @@ nodes:
         vals: <Anything>, value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: Wigner_tomography,
-        label: calibrate_function, name: calibrate_function, ts: '2017-05-28 15:03:52',
+        label: calibrate_function, name: calibrate_function, ts: '2017-06-04 14:24:22',
         unit: '', vals: <Strings>, value: test_calibration_True}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: Wigner_tomography,
-        label: calibration_timeout, name: calibration_timeout, ts: '2017-05-28 15:03:52',
+        label: calibration_timeout, name: calibration_timeout, ts: '2017-06-04 14:24:22',
         unit: s, vals: <Numbers v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
         instrument_name: Wigner_tomography, label: check_function, name: check_function,
-        ts: '2017-05-28 15:03:52', unit: '', vals: <Strings>, value: always_needs_calibration}
+        ts: '2017-06-04 14:24:22', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: Wigner_tomography
         label: children
         name: children
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [Rabi_simulation]
@@ -467,14 +467,14 @@ nodes:
         instrument_name: Wigner_tomography
         label: parents
         name: parents
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [Photon_meter]
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: Wigner_tomography, label: state, name: state, ts: '2017-05-28
-          15:03:52', unit: '', vals: '<Enum: {''unknown'', ''bad'', ''good'', ''needs
-          calibration'', ''active''}>', value: unknown}
+        instrument_name: Wigner_tomography, label: state, name: state, ts: '2017-06-04
+          14:24:22', unit: '', vals: '<Enum: {''active'', ''good'', ''unknown'', ''bad'',
+          ''needs calibration''}>', value: unknown}
   frequency_ramsey:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -485,22 +485,22 @@ nodes:
         vals: <Anything>, value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: frequency_ramsey,
-        label: calibrate_function, name: calibrate_function, ts: '2017-05-28 15:03:52',
+        label: calibrate_function, name: calibrate_function, ts: '2017-06-04 14:24:22',
         unit: '', vals: <Strings>, value: test_calibration_True}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: frequency_ramsey,
-        label: calibration_timeout, name: calibration_timeout, ts: '2017-05-28 15:03:52',
+        label: calibration_timeout, name: calibration_timeout, ts: '2017-06-04 14:24:22',
         unit: s, vals: <Numbers v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
         instrument_name: frequency_ramsey, label: check_function, name: check_function,
-        ts: '2017-05-28 15:03:52', unit: '', vals: <Strings>, value: always_needs_calibration}
+        ts: '2017-06-04 14:24:22', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: frequency_ramsey
         label: children
         name: children
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [Motzoi, High_fidelity_single_qubit_gates]
@@ -510,14 +510,14 @@ nodes:
         instrument_name: frequency_ramsey
         label: parents
         name: parents
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [Amplitude_coarse, SSRO, frequency_spec]
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: frequency_ramsey, label: state, name: state, ts: '2017-05-28
-          15:03:52', unit: '', vals: '<Enum: {''unknown'', ''bad'', ''good'', ''needs
-          calibration'', ''active''}>', value: unknown}
+        instrument_name: frequency_ramsey, label: state, name: state, ts: '2017-06-04
+          14:24:22', unit: '', vals: '<Enum: {''active'', ''good'', ''unknown'', ''bad'',
+          ''needs calibration''}>', value: unknown}
   frequency_spec:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -528,22 +528,22 @@ nodes:
         vals: <Anything>, value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: frequency_spec,
-        label: calibrate_function, name: calibrate_function, ts: '2017-05-28 15:03:52',
+        label: calibrate_function, name: calibrate_function, ts: '2017-06-04 14:24:22',
         unit: '', vals: <Strings>, value: test_calibration_True}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: frequency_spec,
-        label: calibration_timeout, name: calibration_timeout, ts: '2017-05-28 15:03:52',
+        label: calibration_timeout, name: calibration_timeout, ts: '2017-06-04 14:24:22',
         unit: s, vals: <Numbers v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
         instrument_name: frequency_spec, label: check_function, name: check_function,
-        ts: '2017-05-28 15:03:52', unit: '', vals: <Strings>, value: always_needs_calibration}
+        ts: '2017-06-04 14:24:22', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: frequency_spec
         label: children
         name: children
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [Amplitude_coarse, frequency_ramsey]
@@ -553,14 +553,14 @@ nodes:
         instrument_name: frequency_spec
         label: parents
         name: parents
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: frequency_spec, label: state, name: state, ts: '2017-05-28
-          15:03:52', unit: '', vals: '<Enum: {''unknown'', ''bad'', ''good'', ''needs
-          calibration'', ''active''}>', value: unknown}
+        instrument_name: frequency_spec, label: state, name: state, ts: '2017-06-04
+          14:24:22', unit: '', vals: '<Enum: {''active'', ''good'', ''unknown'', ''bad'',
+          ''needs calibration''}>', value: unknown}
   mixer_offset:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -571,22 +571,22 @@ nodes:
         vals: <Anything>, value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: mixer_offset,
-        label: calibrate_function, name: calibrate_function, ts: '2017-05-28 15:03:52',
+        label: calibrate_function, name: calibrate_function, ts: '2017-06-04 14:24:22',
         unit: '', vals: <Strings>, value: test_calibration_True}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: mixer_offset,
-        label: calibration_timeout, name: calibration_timeout, ts: '2017-05-28 15:03:52',
+        label: calibration_timeout, name: calibration_timeout, ts: '2017-06-04 14:24:22',
         unit: s, vals: <Numbers v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
         instrument_name: mixer_offset, label: check_function, name: check_function,
-        ts: '2017-05-28 15:03:52', unit: '', vals: <Strings>, value: always_needs_calibration}
+        ts: '2017-06-04 14:24:22', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: mixer_offset
         label: children
         name: children
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [mixer_skewness, Amplitude_coarse]
@@ -596,14 +596,14 @@ nodes:
         instrument_name: mixer_offset
         label: parents
         name: parents
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: mixer_offset, label: state, name: state, ts: '2017-05-28
-          15:03:52', unit: '', vals: '<Enum: {''unknown'', ''bad'', ''good'', ''needs
-          calibration'', ''active''}>', value: unknown}
+        instrument_name: mixer_offset, label: state, name: state, ts: '2017-06-04
+          14:24:22', unit: '', vals: '<Enum: {''active'', ''good'', ''unknown'', ''bad'',
+          ''needs calibration''}>', value: unknown}
   mixer_skewness:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -614,22 +614,22 @@ nodes:
         vals: <Anything>, value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: mixer_skewness,
-        label: calibrate_function, name: calibrate_function, ts: '2017-05-28 15:03:52',
+        label: calibrate_function, name: calibrate_function, ts: '2017-06-04 14:24:22',
         unit: '', vals: <Strings>, value: test_calibration_True}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: mixer_skewness,
-        label: calibration_timeout, name: calibration_timeout, ts: '2017-05-28 15:03:52',
+        label: calibration_timeout, name: calibration_timeout, ts: '2017-06-04 14:24:22',
         unit: s, vals: <Numbers v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
         instrument_name: mixer_skewness, label: check_function, name: check_function,
-        ts: '2017-05-28 15:03:52', unit: '', vals: <Strings>, value: always_needs_calibration}
+        ts: '2017-06-04 14:24:22', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: mixer_skewness
         label: children
         name: children
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [Amplitude_coarse]
@@ -639,11 +639,11 @@ nodes:
         instrument_name: mixer_skewness
         label: parents
         name: parents
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [mixer_offset]
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: mixer_skewness, label: state, name: state, ts: '2017-05-28
-          15:03:52', unit: '', vals: '<Enum: {''unknown'', ''bad'', ''good'', ''needs
-          calibration'', ''active''}>', value: unknown}
+        instrument_name: mixer_skewness, label: state, name: state, ts: '2017-06-04
+          14:24:22', unit: '', vals: '<Enum: {''active'', ''good'', ''unknown'', ''bad'',
+          ''needs calibration''}>', value: unknown}

--- a/autodepgraph/tests/test_data/test_graph_new_nodes.yaml
+++ b/autodepgraph/tests/test_data/test_graph_new_nodes.yaml
@@ -10,22 +10,22 @@ nodes:
         value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: A, label: calibrate_function,
-        name: calibrate_function, ts: '2017-05-28 15:03:52', unit: '', vals: <Strings>,
-        value: NotImplementedError}
+        name: calibrate_function, ts: '2017-06-04 14:24:22', unit: '', vals: <Strings>,
+        value: NotImplementedCalibration}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: A, label: calibration_timeout,
-        name: calibration_timeout, ts: '2017-05-28 15:03:52', unit: s, vals: <Numbers
+        name: calibration_timeout, ts: '2017-06-04 14:24:22', unit: s, vals: <Numbers
           v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: A, label: check_function, name: check_function, ts: '2017-05-28
-          15:03:52', unit: '', vals: <Strings>, value: state}
+        instrument_name: A, label: check_function, name: check_function, ts: '2017-06-04
+          14:24:22', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: A
         label: children
         name: children
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
@@ -35,14 +35,14 @@ nodes:
         instrument_name: A
         label: parents
         name: parents
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: A, label: state, name: state, ts: '2017-05-28 15:03:52',
-        unit: '', vals: '<Enum: {''unknown'', ''bad'', ''good'', ''needs calibration'',
-          ''active''}>', value: good}
+        instrument_name: A, label: state, name: state, ts: '2017-06-04 14:24:22',
+        unit: '', vals: '<Enum: {''active'', ''good'', ''unknown'', ''bad'', ''needs
+          calibration''}>', value: good}
   B:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -53,22 +53,22 @@ nodes:
         value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: B, label: calibrate_function,
-        name: calibrate_function, ts: '2017-05-28 15:03:52', unit: '', vals: <Strings>,
-        value: NotImplementedError}
+        name: calibrate_function, ts: '2017-06-04 14:24:22', unit: '', vals: <Strings>,
+        value: NotImplementedCalibration}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: B, label: calibration_timeout,
-        name: calibration_timeout, ts: '2017-05-28 15:03:52', unit: s, vals: <Numbers
+        name: calibration_timeout, ts: '2017-06-04 14:24:22', unit: s, vals: <Numbers
           v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: B, label: check_function, name: check_function, ts: '2017-05-28
-          15:03:52', unit: '', vals: <Strings>, value: state}
+        instrument_name: B, label: check_function, name: check_function, ts: '2017-06-04
+          14:24:22', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: B
         label: children
         name: children
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
@@ -78,14 +78,14 @@ nodes:
         instrument_name: B
         label: parents
         name: parents
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: B, label: state, name: state, ts: '2017-05-28 15:03:52',
-        unit: '', vals: '<Enum: {''unknown'', ''bad'', ''good'', ''needs calibration'',
-          ''active''}>', value: bad}
+        instrument_name: B, label: state, name: state, ts: '2017-06-04 14:24:22',
+        unit: '', vals: '<Enum: {''active'', ''good'', ''unknown'', ''bad'', ''needs
+          calibration''}>', value: bad}
   E:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -96,22 +96,22 @@ nodes:
         value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: E, label: calibrate_function,
-        name: calibrate_function, ts: '2017-05-28 15:03:52', unit: '', vals: <Strings>,
-        value: NotImplementedError}
+        name: calibrate_function, ts: '2017-06-04 14:24:22', unit: '', vals: <Strings>,
+        value: NotImplementedCalibration}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: E, label: calibration_timeout,
-        name: calibration_timeout, ts: '2017-05-28 15:03:52', unit: s, vals: <Numbers
+        name: calibration_timeout, ts: '2017-06-04 14:24:22', unit: s, vals: <Numbers
           v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: E, label: check_function, name: check_function, ts: '2017-05-28
-          15:03:52', unit: '', vals: <Strings>, value: state}
+        instrument_name: E, label: check_function, name: check_function, ts: '2017-06-04
+          14:24:22', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: E
         label: children
         name: children
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
@@ -121,14 +121,14 @@ nodes:
         instrument_name: E
         label: parents
         name: parents
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: E, label: state, name: state, ts: '2017-05-28 15:03:52',
-        unit: '', vals: '<Enum: {''unknown'', ''bad'', ''good'', ''needs calibration'',
-          ''active''}>', value: unknown}
+        instrument_name: E, label: state, name: state, ts: '2017-06-04 14:24:22',
+        unit: '', vals: '<Enum: {''active'', ''good'', ''unknown'', ''bad'', ''needs
+          calibration''}>', value: unknown}
   F:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -139,22 +139,22 @@ nodes:
         value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: F, label: calibrate_function,
-        name: calibrate_function, ts: '2017-05-28 15:03:52', unit: '', vals: <Strings>,
-        value: NotImplementedError}
+        name: calibrate_function, ts: '2017-06-04 14:24:22', unit: '', vals: <Strings>,
+        value: NotImplementedCalibration}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: F, label: calibration_timeout,
-        name: calibration_timeout, ts: '2017-05-28 15:03:52', unit: s, vals: <Numbers
+        name: calibration_timeout, ts: '2017-06-04 14:24:22', unit: s, vals: <Numbers
           v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: F, label: check_function, name: check_function, ts: '2017-05-28
-          15:03:52', unit: '', vals: <Strings>, value: state}
+        instrument_name: F, label: check_function, name: check_function, ts: '2017-06-04
+          14:24:22', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: F
         label: children
         name: children
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
@@ -164,11 +164,11 @@ nodes:
         instrument_name: F
         label: parents
         name: parents
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: F, label: state, name: state, ts: '2017-05-28 15:03:52',
-        unit: '', vals: '<Enum: {''unknown'', ''bad'', ''good'', ''needs calibration'',
-          ''active''}>', value: unknown}
+        instrument_name: F, label: state, name: state, ts: '2017-06-04 14:24:22',
+        unit: '', vals: '<Enum: {''active'', ''good'', ''unknown'', ''bad'', ''needs
+          calibration''}>', value: unknown}

--- a/autodepgraph/tests/test_data/test_graph_states.yaml
+++ b/autodepgraph/tests/test_data/test_graph_states.yaml
@@ -10,22 +10,22 @@ nodes:
         value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: A, label: calibrate_function,
-        name: calibrate_function, ts: '2017-05-28 15:03:52', unit: '', vals: <Strings>,
-        value: NotImplementedError}
+        name: calibrate_function, ts: '2017-06-04 14:00:14', unit: '', vals: <Strings>,
+        value: NotImplementedCalibration}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: A, label: calibration_timeout,
-        name: calibration_timeout, ts: '2017-05-28 15:03:52', unit: s, vals: <Numbers
+        name: calibration_timeout, ts: '2017-06-04 14:00:14', unit: s, vals: <Numbers
           v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: A, label: check_function, name: check_function, ts: '2017-05-28
-          15:03:52', unit: '', vals: <Strings>, value: state}
+        instrument_name: A, label: check_function, name: check_function, ts: '2017-06-04
+          14:00:14', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: A
         label: children
         name: children
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:00:14'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [D, B]
@@ -35,14 +35,14 @@ nodes:
         instrument_name: A
         label: parents
         name: parents
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:00:14'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: A, label: state, name: state, ts: '2017-05-28 15:03:52',
-        unit: '', vals: '<Enum: {''unknown'', ''bad'', ''good'', ''needs calibration'',
-          ''active''}>', value: unknown}
+        instrument_name: A, label: state, name: state, ts: '2017-06-04 14:00:14',
+        unit: '', vals: '<Enum: {''active'', ''needs calibration'', ''good'', ''bad'',
+          ''unknown''}>', value: good}
   B:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -53,22 +53,22 @@ nodes:
         value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: B, label: calibrate_function,
-        name: calibrate_function, ts: '2017-05-28 15:03:52', unit: '', vals: <Strings>,
-        value: NotImplementedError}
+        name: calibrate_function, ts: '2017-06-04 14:00:14', unit: '', vals: <Strings>,
+        value: NotImplementedCalibration}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: B, label: calibration_timeout,
-        name: calibration_timeout, ts: '2017-05-28 15:03:52', unit: s, vals: <Numbers
+        name: calibration_timeout, ts: '2017-06-04 14:00:14', unit: s, vals: <Numbers
           v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: B, label: check_function, name: check_function, ts: '2017-05-28
-          15:03:52', unit: '', vals: <Strings>, value: state}
+        instrument_name: B, label: check_function, name: check_function, ts: '2017-06-04
+          14:00:14', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: B
         label: children
         name: children
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:00:14'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [C]
@@ -78,14 +78,14 @@ nodes:
         instrument_name: B
         label: parents
         name: parents
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:00:14'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [A]
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: B, label: state, name: state, ts: '2017-05-28 15:03:52',
-        unit: '', vals: '<Enum: {''unknown'', ''bad'', ''good'', ''needs calibration'',
-          ''active''}>', value: unknown}
+        instrument_name: B, label: state, name: state, ts: '2017-06-04 14:00:14',
+        unit: '', vals: '<Enum: {''active'', ''needs calibration'', ''good'', ''bad'',
+          ''unknown''}>', value: needs calibration}
   C:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -96,22 +96,22 @@ nodes:
         value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: C, label: calibrate_function,
-        name: calibrate_function, ts: '2017-05-28 15:03:52', unit: '', vals: <Strings>,
-        value: NotImplementedError}
+        name: calibrate_function, ts: '2017-06-04 14:00:14', unit: '', vals: <Strings>,
+        value: NotImplementedCalibration}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: C, label: calibration_timeout,
-        name: calibration_timeout, ts: '2017-05-28 15:03:52', unit: s, vals: <Numbers
+        name: calibration_timeout, ts: '2017-06-04 14:00:14', unit: s, vals: <Numbers
           v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: C, label: check_function, name: check_function, ts: '2017-05-28
-          15:03:52', unit: '', vals: <Strings>, value: state}
+        instrument_name: C, label: check_function, name: check_function, ts: '2017-06-04
+          14:00:14', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: C
         label: children
         name: children
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:00:14'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [D]
@@ -121,14 +121,14 @@ nodes:
         instrument_name: C
         label: parents
         name: parents
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:00:14'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [B]
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: C, label: state, name: state, ts: '2017-05-28 15:03:52',
-        unit: '', vals: '<Enum: {''unknown'', ''bad'', ''good'', ''needs calibration'',
-          ''active''}>', value: unknown}
+        instrument_name: C, label: state, name: state, ts: '2017-06-04 14:00:14',
+        unit: '', vals: '<Enum: {''active'', ''needs calibration'', ''good'', ''bad'',
+          ''unknown''}>', value: active}
   D:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -139,22 +139,22 @@ nodes:
         value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: D, label: calibrate_function,
-        name: calibrate_function, ts: '2017-05-28 15:03:52', unit: '', vals: <Strings>,
-        value: NotImplementedError}
+        name: calibrate_function, ts: '2017-06-04 14:00:14', unit: '', vals: <Strings>,
+        value: NotImplementedCalibration}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: D, label: calibration_timeout,
-        name: calibration_timeout, ts: '2017-05-28 15:03:52', unit: s, vals: <Numbers
+        name: calibration_timeout, ts: '2017-06-04 14:00:14', unit: s, vals: <Numbers
           v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: D, label: check_function, name: check_function, ts: '2017-05-28
-          15:03:52', unit: '', vals: <Strings>, value: state}
+        instrument_name: D, label: check_function, name: check_function, ts: '2017-06-04
+          14:00:14', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: D
         label: children
         name: children
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:00:14'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [E, G]
@@ -164,14 +164,14 @@ nodes:
         instrument_name: D
         label: parents
         name: parents
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:00:14'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [C, A]
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: D, label: state, name: state, ts: '2017-05-28 15:03:52',
-        unit: '', vals: '<Enum: {''unknown'', ''bad'', ''good'', ''needs calibration'',
-          ''active''}>', value: unknown}
+        instrument_name: D, label: state, name: state, ts: '2017-06-04 14:00:14',
+        unit: '', vals: '<Enum: {''active'', ''needs calibration'', ''good'', ''bad'',
+          ''unknown''}>', value: bad}
   E:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -182,22 +182,22 @@ nodes:
         value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: E, label: calibrate_function,
-        name: calibrate_function, ts: '2017-05-28 15:03:52', unit: '', vals: <Strings>,
-        value: NotImplementedError}
+        name: calibrate_function, ts: '2017-06-04 14:00:14', unit: '', vals: <Strings>,
+        value: NotImplementedCalibration}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: E, label: calibration_timeout,
-        name: calibration_timeout, ts: '2017-05-28 15:03:52', unit: s, vals: <Numbers
+        name: calibration_timeout, ts: '2017-06-04 14:00:14', unit: s, vals: <Numbers
           v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: E, label: check_function, name: check_function, ts: '2017-05-28
-          15:03:52', unit: '', vals: <Strings>, value: state}
+        instrument_name: E, label: check_function, name: check_function, ts: '2017-06-04
+          14:00:14', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: E
         label: children
         name: children
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:00:14'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
@@ -207,14 +207,14 @@ nodes:
         instrument_name: E
         label: parents
         name: parents
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:00:14'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [D]
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: E, label: state, name: state, ts: '2017-05-28 15:03:52',
-        unit: '', vals: '<Enum: {''unknown'', ''bad'', ''good'', ''needs calibration'',
-          ''active''}>', value: unknown}
+        instrument_name: E, label: state, name: state, ts: '2017-06-04 14:00:14',
+        unit: '', vals: '<Enum: {''active'', ''needs calibration'', ''good'', ''bad'',
+          ''unknown''}>', value: unknown}
   F:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -225,22 +225,22 @@ nodes:
         value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: F, label: calibrate_function,
-        name: calibrate_function, ts: '2017-05-28 15:03:52', unit: '', vals: <Strings>,
-        value: NotImplementedError}
+        name: calibrate_function, ts: '2017-06-04 14:00:14', unit: '', vals: <Strings>,
+        value: NotImplementedCalibration}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: F, label: calibration_timeout,
-        name: calibration_timeout, ts: '2017-05-28 15:03:52', unit: s, vals: <Numbers
+        name: calibration_timeout, ts: '2017-06-04 14:00:14', unit: s, vals: <Numbers
           v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: F, label: check_function, name: check_function, ts: '2017-05-28
-          15:03:52', unit: '', vals: <Strings>, value: state}
+        instrument_name: F, label: check_function, name: check_function, ts: '2017-06-04
+          14:00:14', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: F
         label: children
         name: children
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:00:14'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [G]
@@ -250,14 +250,14 @@ nodes:
         instrument_name: F
         label: parents
         name: parents
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:00:14'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: F, label: state, name: state, ts: '2017-05-28 15:03:52',
-        unit: '', vals: '<Enum: {''unknown'', ''bad'', ''good'', ''needs calibration'',
-          ''active''}>', value: unknown}
+        instrument_name: F, label: state, name: state, ts: '2017-06-04 14:00:14',
+        unit: '', vals: '<Enum: {''active'', ''needs calibration'', ''good'', ''bad'',
+          ''unknown''}>', value: good}
   G:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -268,22 +268,22 @@ nodes:
         value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: G, label: calibrate_function,
-        name: calibrate_function, ts: '2017-05-28 15:03:52', unit: '', vals: <Strings>,
-        value: NotImplementedError}
+        name: calibrate_function, ts: '2017-06-04 14:00:14', unit: '', vals: <Strings>,
+        value: NotImplementedCalibration}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: G, label: calibration_timeout,
-        name: calibration_timeout, ts: '2017-05-28 15:03:52', unit: s, vals: <Numbers
+        name: calibration_timeout, ts: '2017-06-04 14:00:14', unit: s, vals: <Numbers
           v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: G, label: check_function, name: check_function, ts: '2017-05-28
-          15:03:52', unit: '', vals: <Strings>, value: state}
+        instrument_name: G, label: check_function, name: check_function, ts: '2017-06-04
+          14:00:14', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: G
         label: children
         name: children
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:00:14'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [H]
@@ -293,14 +293,14 @@ nodes:
         instrument_name: G
         label: parents
         name: parents
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:00:14'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [F, D]
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: G, label: state, name: state, ts: '2017-05-28 15:03:52',
-        unit: '', vals: '<Enum: {''unknown'', ''bad'', ''good'', ''needs calibration'',
-          ''active''}>', value: unknown}
+        instrument_name: G, label: state, name: state, ts: '2017-06-04 14:00:14',
+        unit: '', vals: '<Enum: {''active'', ''needs calibration'', ''good'', ''bad'',
+          ''unknown''}>', value: unknown}
   H:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -311,22 +311,22 @@ nodes:
         value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: H, label: calibrate_function,
-        name: calibrate_function, ts: '2017-05-28 15:03:52', unit: '', vals: <Strings>,
-        value: NotImplementedError}
+        name: calibrate_function, ts: '2017-06-04 14:00:14', unit: '', vals: <Strings>,
+        value: NotImplementedCalibration}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: H, label: calibration_timeout,
-        name: calibration_timeout, ts: '2017-05-28 15:03:52', unit: s, vals: <Numbers
+        name: calibration_timeout, ts: '2017-06-04 14:00:14', unit: s, vals: <Numbers
           v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: H, label: check_function, name: check_function, ts: '2017-05-28
-          15:03:52', unit: '', vals: <Strings>, value: state}
+        instrument_name: H, label: check_function, name: check_function, ts: '2017-06-04
+          14:00:14', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: H
         label: children
         name: children
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:00:14'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
@@ -336,11 +336,11 @@ nodes:
         instrument_name: H
         label: parents
         name: parents
-        ts: '2017-05-28 15:03:52'
+        ts: '2017-06-04 14:00:14'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [G]
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: H, label: state, name: state, ts: '2017-05-28 15:03:52',
-        unit: '', vals: '<Enum: {''unknown'', ''bad'', ''good'', ''needs calibration'',
-          ''active''}>', value: unknown}
+        instrument_name: H, label: state, name: state, ts: '2017-06-04 14:00:14',
+        unit: '', vals: '<Enum: {''active'', ''needs calibration'', ''good'', ''bad'',
+          ''unknown''}>', value: unknown}

--- a/autodepgraph/tests/test_data/test_graph_states.yaml
+++ b/autodepgraph/tests/test_data/test_graph_states.yaml
@@ -10,22 +10,22 @@ nodes:
         value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: A, label: calibrate_function,
-        name: calibrate_function, ts: '2017-06-04 14:00:14', unit: '', vals: <Strings>,
-        value: NotImplementedCalibration}
+        name: calibrate_function, ts: '2017-06-04 14:24:22', unit: '', vals: <Strings>,
+        value: test_calibration_True}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: A, label: calibration_timeout,
-        name: calibration_timeout, ts: '2017-06-04 14:00:14', unit: s, vals: <Numbers
+        name: calibration_timeout, ts: '2017-06-04 14:24:22', unit: s, vals: <Numbers
           v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
         instrument_name: A, label: check_function, name: check_function, ts: '2017-06-04
-          14:00:14', unit: '', vals: <Strings>, value: always_needs_calibration}
+          14:24:22', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: A
         label: children
         name: children
-        ts: '2017-06-04 14:00:14'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [D, B]
@@ -35,14 +35,14 @@ nodes:
         instrument_name: A
         label: parents
         name: parents
-        ts: '2017-06-04 14:00:14'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: A, label: state, name: state, ts: '2017-06-04 14:00:14',
-        unit: '', vals: '<Enum: {''active'', ''needs calibration'', ''good'', ''bad'',
-          ''unknown''}>', value: good}
+        instrument_name: A, label: state, name: state, ts: '2017-06-04 14:24:22',
+        unit: '', vals: '<Enum: {''active'', ''good'', ''unknown'', ''bad'', ''needs
+          calibration''}>', value: good}
   B:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -53,22 +53,22 @@ nodes:
         value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: B, label: calibrate_function,
-        name: calibrate_function, ts: '2017-06-04 14:00:14', unit: '', vals: <Strings>,
-        value: NotImplementedCalibration}
+        name: calibrate_function, ts: '2017-06-04 14:24:22', unit: '', vals: <Strings>,
+        value: test_calibration_True}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: B, label: calibration_timeout,
-        name: calibration_timeout, ts: '2017-06-04 14:00:14', unit: s, vals: <Numbers
+        name: calibration_timeout, ts: '2017-06-04 14:24:22', unit: s, vals: <Numbers
           v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
         instrument_name: B, label: check_function, name: check_function, ts: '2017-06-04
-          14:00:14', unit: '', vals: <Strings>, value: always_needs_calibration}
+          14:24:22', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: B
         label: children
         name: children
-        ts: '2017-06-04 14:00:14'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [C]
@@ -78,14 +78,14 @@ nodes:
         instrument_name: B
         label: parents
         name: parents
-        ts: '2017-06-04 14:00:14'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [A]
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: B, label: state, name: state, ts: '2017-06-04 14:00:14',
-        unit: '', vals: '<Enum: {''active'', ''needs calibration'', ''good'', ''bad'',
-          ''unknown''}>', value: needs calibration}
+        instrument_name: B, label: state, name: state, ts: '2017-06-04 14:24:22',
+        unit: '', vals: '<Enum: {''active'', ''good'', ''unknown'', ''bad'', ''needs
+          calibration''}>', value: needs calibration}
   C:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -96,22 +96,22 @@ nodes:
         value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: C, label: calibrate_function,
-        name: calibrate_function, ts: '2017-06-04 14:00:14', unit: '', vals: <Strings>,
+        name: calibrate_function, ts: '2017-06-04 14:24:22', unit: '', vals: <Strings>,
         value: NotImplementedCalibration}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: C, label: calibration_timeout,
-        name: calibration_timeout, ts: '2017-06-04 14:00:14', unit: s, vals: <Numbers
+        name: calibration_timeout, ts: '2017-06-04 14:24:22', unit: s, vals: <Numbers
           v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
         instrument_name: C, label: check_function, name: check_function, ts: '2017-06-04
-          14:00:14', unit: '', vals: <Strings>, value: always_needs_calibration}
+          14:24:22', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: C
         label: children
         name: children
-        ts: '2017-06-04 14:00:14'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [D]
@@ -121,14 +121,14 @@ nodes:
         instrument_name: C
         label: parents
         name: parents
-        ts: '2017-06-04 14:00:14'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [B]
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: C, label: state, name: state, ts: '2017-06-04 14:00:14',
-        unit: '', vals: '<Enum: {''active'', ''needs calibration'', ''good'', ''bad'',
-          ''unknown''}>', value: active}
+        instrument_name: C, label: state, name: state, ts: '2017-06-04 14:24:22',
+        unit: '', vals: '<Enum: {''active'', ''good'', ''unknown'', ''bad'', ''needs
+          calibration''}>', value: active}
   D:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -139,22 +139,22 @@ nodes:
         value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: D, label: calibrate_function,
-        name: calibrate_function, ts: '2017-06-04 14:00:14', unit: '', vals: <Strings>,
-        value: NotImplementedCalibration}
+        name: calibrate_function, ts: '2017-06-04 14:24:22', unit: '', vals: <Strings>,
+        value: test_calibration_True}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: D, label: calibration_timeout,
-        name: calibration_timeout, ts: '2017-06-04 14:00:14', unit: s, vals: <Numbers
+        name: calibration_timeout, ts: '2017-06-04 14:24:22', unit: s, vals: <Numbers
           v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
         instrument_name: D, label: check_function, name: check_function, ts: '2017-06-04
-          14:00:14', unit: '', vals: <Strings>, value: always_needs_calibration}
+          14:24:22', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: D
         label: children
         name: children
-        ts: '2017-06-04 14:00:14'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [E, G]
@@ -164,14 +164,14 @@ nodes:
         instrument_name: D
         label: parents
         name: parents
-        ts: '2017-06-04 14:00:14'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [C, A]
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: D, label: state, name: state, ts: '2017-06-04 14:00:14',
-        unit: '', vals: '<Enum: {''active'', ''needs calibration'', ''good'', ''bad'',
-          ''unknown''}>', value: bad}
+        instrument_name: D, label: state, name: state, ts: '2017-06-04 14:24:22',
+        unit: '', vals: '<Enum: {''active'', ''good'', ''unknown'', ''bad'', ''needs
+          calibration''}>', value: bad}
   E:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -182,22 +182,22 @@ nodes:
         value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: E, label: calibrate_function,
-        name: calibrate_function, ts: '2017-06-04 14:00:14', unit: '', vals: <Strings>,
-        value: NotImplementedCalibration}
+        name: calibrate_function, ts: '2017-06-04 14:24:22', unit: '', vals: <Strings>,
+        value: test_calibration_True}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: E, label: calibration_timeout,
-        name: calibration_timeout, ts: '2017-06-04 14:00:14', unit: s, vals: <Numbers
+        name: calibration_timeout, ts: '2017-06-04 14:24:22', unit: s, vals: <Numbers
           v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
         instrument_name: E, label: check_function, name: check_function, ts: '2017-06-04
-          14:00:14', unit: '', vals: <Strings>, value: always_needs_calibration}
+          14:24:22', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: E
         label: children
         name: children
-        ts: '2017-06-04 14:00:14'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
@@ -207,14 +207,14 @@ nodes:
         instrument_name: E
         label: parents
         name: parents
-        ts: '2017-06-04 14:00:14'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [D]
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: E, label: state, name: state, ts: '2017-06-04 14:00:14',
-        unit: '', vals: '<Enum: {''active'', ''needs calibration'', ''good'', ''bad'',
-          ''unknown''}>', value: unknown}
+        instrument_name: E, label: state, name: state, ts: '2017-06-04 14:24:22',
+        unit: '', vals: '<Enum: {''active'', ''good'', ''unknown'', ''bad'', ''needs
+          calibration''}>', value: unknown}
   F:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -225,22 +225,22 @@ nodes:
         value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: F, label: calibrate_function,
-        name: calibrate_function, ts: '2017-06-04 14:00:14', unit: '', vals: <Strings>,
+        name: calibrate_function, ts: '2017-06-04 14:24:22', unit: '', vals: <Strings>,
         value: NotImplementedCalibration}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: F, label: calibration_timeout,
-        name: calibration_timeout, ts: '2017-06-04 14:00:14', unit: s, vals: <Numbers
+        name: calibration_timeout, ts: '2017-06-04 14:24:22', unit: s, vals: <Numbers
           v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
         instrument_name: F, label: check_function, name: check_function, ts: '2017-06-04
-          14:00:14', unit: '', vals: <Strings>, value: always_needs_calibration}
+          14:24:22', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: F
         label: children
         name: children
-        ts: '2017-06-04 14:00:14'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [G]
@@ -250,14 +250,14 @@ nodes:
         instrument_name: F
         label: parents
         name: parents
-        ts: '2017-06-04 14:00:14'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: F, label: state, name: state, ts: '2017-06-04 14:00:14',
-        unit: '', vals: '<Enum: {''active'', ''needs calibration'', ''good'', ''bad'',
-          ''unknown''}>', value: good}
+        instrument_name: F, label: state, name: state, ts: '2017-06-04 14:24:22',
+        unit: '', vals: '<Enum: {''active'', ''good'', ''unknown'', ''bad'', ''needs
+          calibration''}>', value: good}
   G:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -268,22 +268,22 @@ nodes:
         value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: G, label: calibrate_function,
-        name: calibrate_function, ts: '2017-06-04 14:00:14', unit: '', vals: <Strings>,
-        value: NotImplementedCalibration}
+        name: calibrate_function, ts: '2017-06-04 14:24:22', unit: '', vals: <Strings>,
+        value: test_calibration_True}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: G, label: calibration_timeout,
-        name: calibration_timeout, ts: '2017-06-04 14:00:14', unit: s, vals: <Numbers
+        name: calibration_timeout, ts: '2017-06-04 14:24:22', unit: s, vals: <Numbers
           v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
         instrument_name: G, label: check_function, name: check_function, ts: '2017-06-04
-          14:00:14', unit: '', vals: <Strings>, value: always_needs_calibration}
+          14:24:22', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: G
         label: children
         name: children
-        ts: '2017-06-04 14:00:14'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [H]
@@ -293,14 +293,14 @@ nodes:
         instrument_name: G
         label: parents
         name: parents
-        ts: '2017-06-04 14:00:14'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [F, D]
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: G, label: state, name: state, ts: '2017-06-04 14:00:14',
-        unit: '', vals: '<Enum: {''active'', ''needs calibration'', ''good'', ''bad'',
-          ''unknown''}>', value: unknown}
+        instrument_name: G, label: state, name: state, ts: '2017-06-04 14:24:22',
+        unit: '', vals: '<Enum: {''active'', ''good'', ''unknown'', ''bad'', ''needs
+          calibration''}>', value: unknown}
   H:
     __class__: autodepgraph.node.CalibrationNode
     functions: {}
@@ -311,22 +311,22 @@ nodes:
         value: null}
       calibrate_function: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: H, label: calibrate_function,
-        name: calibrate_function, ts: '2017-06-04 14:00:14', unit: '', vals: <Strings>,
-        value: NotImplementedCalibration}
+        name: calibrate_function, ts: '2017-06-04 14:24:22', unit: '', vals: <Strings>,
+        value: test_calibration_True}
       calibration_timeout: {__class__: qcodes.instrument.parameter.ManualParameter,
         instrument: autodepgraph.node.CalibrationNode, instrument_name: H, label: calibration_timeout,
-        name: calibration_timeout, ts: '2017-06-04 14:00:14', unit: s, vals: <Numbers
+        name: calibration_timeout, ts: '2017-06-04 14:24:22', unit: s, vals: <Numbers
           v>=0>, value: .inf}
       check_function: {__class__: qcodes.instrument.parameter.ManualParameter, instrument: autodepgraph.node.CalibrationNode,
         instrument_name: H, label: check_function, name: check_function, ts: '2017-06-04
-          14:00:14', unit: '', vals: <Strings>, value: always_needs_calibration}
+          14:24:22', unit: '', vals: <Strings>, value: always_needs_calibration}
       children:
         __class__: qcodes.instrument.parameter.StandardParameter
         instrument: autodepgraph.node.CalibrationNode
         instrument_name: H
         label: children
         name: children
-        ts: '2017-06-04 14:00:14'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: []
@@ -336,11 +336,11 @@ nodes:
         instrument_name: H
         label: parents
         name: parents
-        ts: '2017-06-04 14:00:14'
+        ts: '2017-06-04 14:24:22'
         unit: ''
         vals: '<Lists : <Strings>>'
         value: [G]
       state: {__class__: qcodes.instrument.parameter.StandardParameter, instrument: autodepgraph.node.CalibrationNode,
-        instrument_name: H, label: state, name: state, ts: '2017-06-04 14:00:14',
-        unit: '', vals: '<Enum: {''active'', ''needs calibration'', ''good'', ''bad'',
-          ''unknown''}>', value: unknown}
+        instrument_name: H, label: state, name: state, ts: '2017-06-04 14:24:22',
+        unit: '', vals: '<Enum: {''active'', ''good'', ''unknown'', ''bad'', ''needs
+          calibration''}>', value: unknown}

--- a/autodepgraph/tests/test_visualization.py
+++ b/autodepgraph/tests/test_visualization.py
@@ -16,6 +16,24 @@ class Test_visualization(TestCase):
         self.test_graph = Graph('test_graph')
         self.test_graph.load_graph(fn, load_node_state=True)
 
+    @unittest.skip('Test not implemented')
+    def test_get_node_symbols(self):
+        snap = self.test_graph.snapshot()
+
+        raise NotImplementedError()
+
+    def test_get_state_col_map(self):
+        vis.state_cmap
+        snap = self.test_graph.snapshot()
+        cm = vis.get_state_col_map(snap)
+
+        # the check checks for certain known states in the test graph
+        self.assertEqual(cm['A'], vis.state_cmap['good'])
+        self.assertEqual(cm['B'], vis.state_cmap['needs calibration'])
+        self.assertEqual(cm['C'], vis.state_cmap['active'])
+        self.assertEqual(cm['D'], vis.state_cmap['bad'])
+        self.assertEqual(cm['E'], vis.state_cmap['unknown'])
+
     def test_snapshot_to_nxGraph(self):
         snap = self.test_graph.snapshot()
         nxG = vis.snapshot_to_nxGraph(snap)
@@ -24,10 +42,6 @@ class Test_visualization(TestCase):
         dep_edges = set([('D', 'C'), ('D', 'A'), ('E', 'D'), ('G', 'F'),
                         ('C', 'B'), ('B', 'A'), ('G', 'D'), ('H', 'G')])
         self.assertEqual(set(nxG.edges()), dep_edges)
-
-    @unittest.skip('Test not impemented')
-    def test_get_state_col_map(self):
-        raise NotImplementedError()
 
     def test_draw_graph_mpl(self):
         # This test only tests if the plotting runs and does not check if

--- a/autodepgraph/tests/test_visualization.py
+++ b/autodepgraph/tests/test_visualization.py
@@ -11,9 +11,9 @@ class Test_visualization(TestCase):
 
     @classmethod
     def setUpClass(self):
-        fn = os.path.join(test_dir, 'test_graph_states.yaml')
+        self.fn = os.path.join(test_dir, 'test_graph_states.yaml')
         self.test_graph = Graph('test_graph')
-        self.test_graph.load_graph(fn, load_node_state=True)
+        self.test_graph.load_graph(self.fn, load_node_state=True)
 
     def test_get_node_symbols(self):
         snap = self.test_graph.snapshot()
@@ -35,6 +35,8 @@ class Test_visualization(TestCase):
         self.assertEqual(cm['E'], vis.state_cmap['unknown'])
 
     def test_snapshot_to_nxGraph(self):
+        # ensures that the graph is returned to the state from before this
+        # test.
         snap = self.test_graph.snapshot()
         nxG = vis.snapshot_to_nxGraph(snap)
         self.assertEqual(set(nxG.nodes()),
@@ -52,14 +54,28 @@ class Test_visualization(TestCase):
         self.test_graph.plot_mode = 'mpl'
         self.test_graph.update_monitor()
 
-    def test_draw_graph_pyqt(self):
+    def test_graph_changed_correct_plotting(self):
         # This test only tests if the plotting runs and does not check if
         # it is correct
-        snap = self.test_graph.snapshot()
+        self.test_graph_2 = Graph('test_graph_2')
+        self.test_graph_2.load_graph(self.fn, load_node_state=True)
+        snap = self.test_graph_2.snapshot()
         DiGraphWindow = vis.draw_graph_pyqt(snap)
         # Updating and reusing the same plot
         DiGraphWindow = vis.draw_graph_pyqt(snap, DiGraphWindow=DiGraphWindow)
 
+        self.test_graph_2.plot_mode = 'pg'
+        self.test_graph_2.update_monitor()
+        self.assertEqual(self.test_graph_2._graph_changed_since_plot, False)
+        nodeJ = self.test_graph_2.add_node('J')
+        nodeJ.parents(['G'])
+        self.assertEqual(self.test_graph_2._graph_changed_since_plot, True)
+        self.test_graph_2.update_monitor()
+        nodeJ.remove_parent('G')
+
+    def test_draw_graph_pyqt(self):
+        # This test only tests if the plotting runs and does not check if
+        # it is correct
         self.test_graph.plot_mode = 'pg'
         self.test_graph.update_monitor()
 

--- a/autodepgraph/tests/test_visualization.py
+++ b/autodepgraph/tests/test_visualization.py
@@ -23,7 +23,6 @@ class Test_visualization(TestCase):
         self.assertEqual(sm['C'], vis.type_symbol_map['manual_cal'])
 
     def test_get_state_col_map(self):
-        vis.state_cmap
         snap = self.test_graph.snapshot()
         cm = vis.get_state_col_map(snap)
 

--- a/autodepgraph/tests/test_visualization.py
+++ b/autodepgraph/tests/test_visualization.py
@@ -16,11 +16,12 @@ class Test_visualization(TestCase):
         self.test_graph = Graph('test_graph')
         self.test_graph.load_graph(fn, load_node_state=True)
 
-    @unittest.skip('Test not implemented')
     def test_get_node_symbols(self):
         snap = self.test_graph.snapshot()
+        sm = vis.get_type_symbol_map(snap)
 
-        raise NotImplementedError()
+        self.assertEqual(sm['A'], vis.type_symbol_map['normal'])
+        self.assertEqual(sm['C'], vis.type_symbol_map['manual_cal'])
 
     def test_get_state_col_map(self):
         vis.state_cmap

--- a/autodepgraph/tests/test_visualization.py
+++ b/autodepgraph/tests/test_visualization.py
@@ -2,7 +2,6 @@ import os
 import qcodes as qc
 from autodepgraph.graph import Graph
 from autodepgraph import visualization as vis
-import unittest
 from unittest import TestCase
 import autodepgraph as adg
 test_dir = os.path.join(adg.__path__[0], 'tests', 'test_data')

--- a/autodepgraph/tests/write_test_graphs.py
+++ b/autodepgraph/tests/write_test_graphs.py
@@ -57,6 +57,12 @@ nodeB.add_parent('A')
 nodeG.add_parent('D')
 nodeH.add_parent('G')
 
+for node in a.nodes.values():
+    node.calibrate_function('test_calibration_True')
+nodeC.calibrate_function('NotImplementedCalibration')
+nodeF.calibrate_function('NotImplementedCalibration')
+
+
 a.save_graph(os.path.join(test_dir, 'test_graph_states.yaml'))
 
 for node in a.nodes.values():

--- a/autodepgraph/tests/write_test_graphs.py
+++ b/autodepgraph/tests/write_test_graphs.py
@@ -27,6 +27,7 @@ nodeA.state('good')
 nodeB.state('bad')
 nodeE.state('unknown')
 
+
 a.save_graph(os.path.join(test_dir, 'test_graph_new_nodes.yaml'))
 
 # Write graph for test_visualization
@@ -41,10 +42,12 @@ a.add_node('D')
 a.add_node('G')
 a.add_node('H')
 
-nodeA.state('unknown')
-nodeB.state('unknown')
+nodeA.state('good')
+nodeB.state('needs calibration')
+nodeD.state('bad')
 nodeE.state('unknown')
-
+nodeF.state('good')
+nodeC.state('active')
 nodeD.add_parent('C')
 nodeD.add_parent('A')
 nodeE.add_parent('D')

--- a/autodepgraph/visualization.py
+++ b/autodepgraph/visualization.py
@@ -10,11 +10,14 @@ state_cmap = {'unknown': '#7f7f7f',            # middle gray
               'bad': '#d62728',                # brick red
               }
 
+type_symbol_map = {'normal': 'o',              # a circle
+                   'manual_cal': 'h', }        # a hexagon
+
 
 def get_state_col_map(snapshot):
     """
     Creates a dictionary with node names as keys and their state dependent
-    color as item.
+    color as value.
     """
     col_map = {}
     for node in snapshot['nodes'].values():
@@ -22,6 +25,28 @@ def get_state_col_map(snapshot):
             state_cmap[node['parameters']['state']['value']]
 
     return col_map
+
+
+def get_type_symbol_map(snapshot):
+    """
+    Returns a dictionary with node names as keys and a type dependent symbol
+    as value.
+
+    Currently there is only a distinction between "normal" nodes and
+    "manual_cal" nodes. "manual_cal" nodes are those nodes that do not have
+    a calibrate function specified and as such need to be set by hand.
+    Normal nodes are all other nodes.
+    """
+    symb_map = {}
+    for node in snapshot['nodes'].values():
+        if (node['parameters']['calibrate_function']['value']
+                == 'NotImplementedCalibration'):
+            state = 'manual_cal'
+        else:
+            state = 'normal'
+        symb_map[node['name']] = \
+            type_symbol_map[state]
+    return symb_map
 
 
 def snapshot_to_nxGraph(snapshot):
@@ -124,7 +149,10 @@ def draw_graph_pyqt(snapshot, DiGraphWindow=None, pos=None, layout='spring'):
     cm = get_state_col_map(snapshot)
     colors_list = [(cm[node]) for node in pos_dict.keys()]
 
-    symbols = ['o']*len(pos)
+    sm = get_type_symbol_map(snapshot)
+    symbols = [(sm[node]) for node in pos_dict.keys()]
+
+    # symbols = ['o']*len(pos)
     labels = list(pos_dict.keys())
 
     if DiGraphWindow is None:

--- a/autodepgraph/visualization.py
+++ b/autodepgraph/visualization.py
@@ -64,14 +64,13 @@ def snapshot_to_nxGraph(snapshot):
     return nxG
 
 
-def draw_graph_mpl(snapshot, pos=None, layout='spring'):
+def draw_graph_mpl(snapshot, pos=None):
     """
     Function to create a quick plot of a graph using matplotlib.
     Intended mostly for for debugging purposes
     Args:
-        snapshot
-        layout (str) : layout to position the nodes options are:
-            spring, shell, spectral and circular.
+        snapshot    snapshot snapshot of the graph
+        pos         positions of the nodes
     returns:
         pos
 
@@ -115,14 +114,15 @@ def adjaceny_to_integers(nxG, pos_dict):
     return adj
 
 
-def draw_graph_pyqt(snapshot, DiGraphWindow=None):
+def draw_graph_pyqt(snapshot, DiGraphWindow=None, window_title=None):
     """
     Function to create a quick plot of a graph using matplotlib.
     Intended mostly for for debugging purposes
     Args:
-        snapshot : snapshot of the graph
-        DiGraphWindow     : pyqtgraph remote graph window to be updated
+        snapshot        : snapshot of the graph
+        DiGraphWindow   : pyqtgraph remote graph window to be updated
             if None it will create a new plotting window to update
+        window_title    : title of the plotting window
     returns:
         DiGraphWindow
 
@@ -144,7 +144,7 @@ def draw_graph_pyqt(snapshot, DiGraphWindow=None):
     labels = list(pos_dict.keys())
 
     if DiGraphWindow is None:
-        DiGraphWindow = pg_DiGraph_window()
+        DiGraphWindow = pg_DiGraph_window(window_title=window_title)
 
     DiGraphWindow.setData(pos=np.array(pos), adj=adj, size=20, symbol=symbols,
                           labels=labels, pen=(60, 60, 60),

--- a/autodepgraph/visualization.py
+++ b/autodepgraph/visualization.py
@@ -78,16 +78,7 @@ def draw_graph_mpl(snapshot, pos=None, layout='spring'):
     """
     nxG = snapshot_to_nxGraph(snapshot)
     if pos is None:
-        if layout == 'spring':
-            pos = nx.spring_layout(nxG, iterations=5000)
-        elif layout == 'shell':
-            pos = nx.shell_layout(nxG)
-        elif layout == 'spectral':
-            pos = nx.spectral_layout(nxG)
-        elif layout == 'circular':
-            pos = nx.circular_layout(nxG)
-        else:
-            raise ValueError('layout not recognized')
+        pos = nx.spring_layout(nxG, iterations=5000)
 
     # Edge colors need to be set using a value mapping and a cmap
 

--- a/autodepgraph/visualization.py
+++ b/autodepgraph/visualization.py
@@ -115,7 +115,7 @@ def adjaceny_to_integers(nxG, pos_dict):
     return adj
 
 
-def draw_graph_pyqt(snapshot, DiGraphWindow=None, pos=None, layout='spring'):
+def draw_graph_pyqt(snapshot, DiGraphWindow=None):
     """
     Function to create a quick plot of a graph using matplotlib.
     Intended mostly for for debugging purposes
@@ -123,10 +123,8 @@ def draw_graph_pyqt(snapshot, DiGraphWindow=None, pos=None, layout='spring'):
         snapshot : snapshot of the graph
         DiGraphWindow     : pyqtgraph remote graph window to be updated
             if None it will create a new plotting window to update
-        layout (str) : layout to position the nodes options are:
-            spring, shell, spectral and circular.
     returns:
-        pos
+        DiGraphWindow
 
     """
     nxG = snapshot_to_nxGraph(snapshot)
@@ -143,7 +141,6 @@ def draw_graph_pyqt(snapshot, DiGraphWindow=None, pos=None, layout='spring'):
     sm = get_type_symbol_map(snapshot)
     symbols = [(sm[node]) for node in pos_dict.keys()]
 
-    # symbols = ['o']*len(pos)
     labels = list(pos_dict.keys())
 
     if DiGraphWindow is None:


### PR DESCRIPTION
Closes #30 and #34 . 

- nodes that have the NotImplementedCalibration are automatically marked as manual nodes, having a hexagon as a symbol 
- added a window title to plotting monitors 

Also includes the following changes
- updating the graph when nodes have been added automatically clears the monitor before updating
-  added a test for the color map 
- removed some layout options from the matplotlib plotting 
- monitor updates before raising an error encountered. 