### PR TITLE
allow setting parents while adding a node

### DIFF
--- a/autodepgraph/graph.py
+++ b/autodepgraph/graph.py
@@ -84,7 +84,7 @@ class Graph(Instrument):
             snap['nodes'][node.name] = node.snapshot(update=update)
         return snap
 
-    def add_node(self, node):
+    def add_node(self, node,  parents=None):
         """
         Adds a node to the graph.
         Args:
@@ -107,6 +107,9 @@ class Graph(Instrument):
         # is added
         self._node_pos = None
         self._graph_changed_since_plot = True
+
+        if parents is not None:
+            node.parents(parents)
 
         return node
 


### PR DESCRIPTION
add the `parent` parameter to Graph.add_node(), setting node.parents
immediately after adding the node (allows to build a new graph in less
lines).