### PR TITLE
using QCoDeS version of validator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ install:
     - conda create -n test_env python=${PYTHON} --yes
     - source activate test_env
     - conda install numpy scipy pyopengl pytest flake8 six coverage --yes
-    - conda install numpy scipy pyopengl pytest flake8 six coverage --yes
     - conda install -c bioconda pygraphviz --yes
     - echo ${QT}
     - echo ${TEST}
@@ -33,8 +32,9 @@ install:
     - conda install pyqt --yes;
 
     - pip install --upgrade pip
-    - pip install -r requirements.txt
-    - pip install jsonschema # missing dependency in qcodes
+    - pip install qcodes, PyYAML, networkx, matplotlib, pyqtgraph, jsonschema
+    # Have to be selective about how packages get installed due to strange error on Travis
+    # - pip install -r requirements.txt
     - pip install coverage pytest-cov pytest --upgrade
     - pip install codacy-coverage
     - pip install -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ install:
     - conda install pyqt --yes;
 
     - pip install --upgrade pip
-    - pip install qcodes, PyYAML, networkx, matplotlib, pyqtgraph, jsonschema
     # Have to be selective about how packages get installed due to strange error on Travis
     # - pip install -r requirements.txt
+    - pip install qcodes PyYAML networkx matplotlib pyqtgraph jsonschema
     - pip install coverage pytest-cov pytest --upgrade
     - pip install codacy-coverage
     - pip install -e .

--- a/autodepgraph/node.py
+++ b/autodepgraph/node.py
@@ -66,7 +66,8 @@ class CalibrationNode(Instrument):
         self.add_parameter('check_function',
                            docstring=chk_docst,
                            initial_value='always_needs_calibration',
-                           vals=vals.MultiType(vals.Strings(), Callable()),
+                           vals=vals.MultiType(vals.Strings(),
+                                               vals.Callable()),
                            parameter_class=FunctionParameter)
         cal_docst = (
             'Name of the function used to calibrate a node, can be either a '
@@ -78,7 +79,8 @@ class CalibrationNode(Instrument):
         self.add_parameter('calibrate_function',
                            docstring=cal_docst,
                            initial_value='NotImplementedCalibration',
-                           vals=vals.MultiType(vals.Strings(), Callable()),
+                           vals=vals.MultiType(vals.Strings(),
+                                               vals.Callable()),
                            parameter_class=FunctionParameter)
 
         # counters to count how often functions get called for debugging
@@ -382,20 +384,3 @@ class FunctionParameter(ManualParameter):
                 # Look in the calibration_functions file
                 f = getattr(cal_f, funcStr)
         return f
-
-
-class Callable(vals.Validator):
-    """
-    requires a function
-    """
-    def __init__(self):
-        # exists only to overwrite parent class
-        pass
-
-    def validate(self, value, context=''):
-        if not hasattr(value, '__call__'):
-            raise TypeError(
-                '{} is not a callable; {}'.format(repr(value), context))
-
-    def __repr__(self):
-        return '<Callable>'

--- a/autodepgraph/visualization.py
+++ b/autodepgraph/visualization.py
@@ -98,7 +98,7 @@ def snapshot_to_nxGraph(snapshot, add_attributes:bool =True):
         # when a .dot renderer
         for node_name, node_snap in g_snap.items():
             attr_dict = get_attr_dict_from_node_snaphshot(node_snap)
-            nxG.add_node(node_name, attr_dict)
+            nxG.add_node(node_name, **attr_dict)
     else:
         nxG.add_nodes_from(g_snap)
     for node_name, n_snap in g_snap.items():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 qcodes
 PyYAML
-networkx
+networkx>=2.1
 matplotlib
 pygraphviz
 pyqtgraph


### PR DESCRIPTION
The callable validator was merged as a pull request into QCoDes. The version of AutoDepGraph was broken because the validators have a new attribute added that this version did not have. Using the QCoDeS version should fix the broken test suites